### PR TITLE
Rename setAttributes helper functions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 CHANGES
 =======
 
+- `Client` class
+    * Renamed `setAttributes(Iterable<Pair>)` method to `loadAttributes(Iterable<Pair>)`.
+- `Service` class
+    * Renamed `setAttributes(Iterable<Pair>)` method to `loadAttributes(Iterable<Pair>)`.
+
 2.88 (2021-02-21)
 -----------------
 

--- a/src/main/java/com/authlete/common/dto/Client.java
+++ b/src/main/java/com/authlete/common/dto/Client.java
@@ -2992,7 +2992,7 @@ public class Client implements Serializable
 
 
     /**
-     * Set attributes.
+     * Load attributes from an iterable.
      *
      * <p>
      * The feature of "client attributes" is available since Authlete 2.2.
@@ -3004,9 +3004,9 @@ public class Client implements Serializable
      * @return
      *     {@code this} object.
      *
-     * @since 2.87
+     * @since 2.89
      */
-    public Client setAttributes(Iterable<Pair> attributes)
+    public Client loadAttributes(Iterable<Pair> attributes)
     {
         if (attributes == null)
         {

--- a/src/main/java/com/authlete/common/dto/Service.java
+++ b/src/main/java/com/authlete/common/dto/Service.java
@@ -5324,7 +5324,7 @@ public class Service implements Serializable
 
 
     /**
-     * Set attributes.
+     * Load attributes from an iterable.
      *
      * <p>
      * The feature of "service attributes" is available since Authlete 2.2.
@@ -5336,9 +5336,9 @@ public class Service implements Serializable
      * @return
      *     {@code this} object.
      *
-     * @since 2.87
+     * @since 2.89
      */
-    public Service setAttributes(Iterable<Pair> attributes)
+    public Service loadAttributes(Iterable<Pair> attributes)
     {
         if (attributes == null)
         {


### PR DESCRIPTION
Renames the setAttributes(Iterable<Pair>) functions in Client and Service to loadAttributes to avoid problems with some JSON serializers.
