### PR TITLE
converting the GPG key id to a reference

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -214,7 +214,7 @@
                             <goal>sign</goal>
                         </goals>
                         <configuration>
-                            <keyname>E834481D</keyname>
+                            <keyname>${gpg.keyname}</keyname>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
This PR removes the hardcoded reference to the GPG key for signing the jar. 
To build the jar locally, a changed pom.xml is required. 
The GPG key id can be configured locally using settings.xml like below:

`... <profiles>
 <profile>
 <id>authlete</id> 
<activation> <activeByDefault>true</activeByDefault> </activation> 
<properties> <gpg.keyname>XXXXXX</gpg.keyname> </properties> 
</profile>  ... `
