### PR TITLE
[feature] OIDC4IDA / assurance_details

### DIFF
--- a/CHANGES.ja.md
+++ b/CHANGES.ja.md
@@ -1,6 +1,11 @@
 変更点
 ======
 
+- `DatasetExtractor` クラス
+    * https://bitbucket.org/openid/ekyc-ida/pull-requests/113 により追加された
+      `assurance_details` プロパティー用の特別規則を実装
+
+
 3.18 (2022 年 04 月 30 日)
 --------------------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 CHANGES
 =======
 
+- `DatasetExtractor` class
+    * Implemented the special rule for the `assurance_details` property which
+      was added by https://bitbucket.org/openid/ekyc-ida/pull-requests/113
+
+
 3.18 (2022-04-30)
 -----------------
 

--- a/src/main/java/com/authlete/common/ida/DatasetExtractor.java
+++ b/src/main/java/com/authlete/common/ida/DatasetExtractor.java
@@ -246,6 +246,13 @@ public class DatasetExtractor
 
 
     /**
+     * The key "assurance_details" which may appear in
+     * "verified_claims/verification/assurance_process".
+     */
+    private static final String KEY_ASSURANCE_DETAILS = "assurance_details";
+
+
+    /**
      * Time used for the "max_age" constraint.
      */
     private final OffsetDateTime mCurrentTime;
@@ -631,6 +638,34 @@ public class DatasetExtractor
         {
             // The property is unavailable, and therefore omitted.
             trace(context, requestValue, originalValue, DE02);
+
+            return true;
+        }
+
+        // If the key is "assurance_details".
+        if (requestKey.equals(KEY_ASSURANCE_DETAILS))
+        {
+            // "assurance_details" has a special rule.
+            //
+            // OpenID Connect for Identity Assurance 1.0
+            // 6.2. Requesting Verification Data
+            //
+            //   assurance_details is an array representing how the evidence and
+            //   check_details meets the requirements of the trust_framework. RP
+            //   SHOULD only request this where they need to know this information.
+            //   Where assurance_details have been requested by an RP the OP MUST
+            //   return the assurance_details element along with all sub-elements
+            //   that it has. If an RP wants to filter what types of evidence and
+            //   check_methods they MUST use those methods to do so, e.g.
+            //   requesting an assurance_type should have no filtering effect.
+
+            // All available sub-elements under 'assurance_details' are
+            // unconditionally returned based on the special rule for the property.
+            trace(context, requestValue, originalValue, DE23);
+
+            // Copy all available sub-elements under 'assurance_details' without
+            // applying any filtering rules.
+            copy.put(requestKey, originalValue);
 
             return true;
         }

--- a/src/main/java/com/authlete/common/ida/DatasetExtractorMessageCode.java
+++ b/src/main/java/com/authlete/common/ida/DatasetExtractorMessageCode.java
@@ -95,6 +95,9 @@ enum DatasetExtractorMessageCode
 
     /** Some elements in the array in the original dataset satisfy any of the elements in the array in the request. */
     DE22,
+
+    /** All available sub-elements under 'assurance_details' are unconditionally returned based on the special rule for the property. */
+    DE23,
     ;
 
 

--- a/src/main/resources/dataset-extractor-messages.properties
+++ b/src/main/resources/dataset-extractor-messages.properties
@@ -20,3 +20,4 @@ DE19 = The element in the array in the request is not an object. It is a specifi
 DE20 = The element in the array in the original dataset satisfies conditions of the element in the array in the request.
 DE21 = None of the elements in the array in the original dataset satisfy any of the elements in the array in the request. Therefore, matching fails.
 DE22 = Some elements in the array in the original dataset satisfy any of the elements in the array in the request.
+DE23 = All available sub-elements under 'assurance_details' are unconditionally returned based on the special rule for the property.

--- a/src/test/java/com/authlete/common/ida/DatasetExtractorTest.java
+++ b/src/test/java/com/authlete/common/ida/DatasetExtractorTest.java
@@ -881,4 +881,51 @@ public class DatasetExtractorTest
 
         assertEquals("The dataset is different from the expected one.", expectedDigest, actualDigest);
     }
+
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testAssuranceDetails()
+    {
+        Object original = getDataset(EVIDENCE_WITH_ASSURANCE_DETAILS);
+        Map<String, Object> request = fromJson(
+                "{" +
+                  "\"verification\":{" +
+                    "\"trust_framework\":null," +
+                    "\"assurance_process\":{" +
+                      "\"assurance_details\":null" +
+                    "}" +
+                  "}," +
+                  "\"claims\":{" +
+                    "\"given_name\":null" +
+                  "}" +
+                "}"
+        );
+
+        Map<String, Object> dataset = extract(request, original);
+        assertNotNull("dataset is null.", dataset);
+
+        Map<String, Object> verification = (Map<String, Object>)dataset.get("verification");
+        assertNotNull("'verification' is null.", verification);
+
+        Map<String, Object> assuranceProcess = (Map<String, Object>)verification.get("assurance_process");
+        assertNotNull("'assurance_process' is null.", assuranceProcess);
+
+        // "assurance_details" has a special rule. When it is requested,
+        // all available sub-elements must be returned.
+
+        List<?> assuranceDetails = (List<?>)assuranceProcess.get("assurance_details");
+        assertNotNull("'assurance_details' is null.", assuranceDetails);
+
+        // Check the number of the "assurance_details" array.
+        assertEquals("The number of elements in 'assurance_details' is wrong.", 3, assuranceDetails.size());
+
+        // The first element in the "assurance_details" array.
+        Map<String, Object> first = (Map<String, Object>)assuranceDetails.get(0);
+        assertNotNull("The first element in the 'assurance_details' array is null.", first);
+
+        // Check the properties of the element.
+        assertEquals("'assurance_type' is wrong.", "evidence_validation", (String)first.get("assurance_type"));
+        assertEquals("'assurance_classification' is wrong.", "score_2", (String)first.get("assurance_classification"));
+    }
 }


### PR DESCRIPTION
Implemented the special rule for the "assurance_details" property which was added by https://bitbucket.org/openid/ekyc-ida/pull-requests/113

The special rule requires that the IdP return all available sub-elements of "assurance_details" when the property is requested.