### PR TITLE
[spec] OpenID4VCI / Credential Issuer Metadata

### DIFF
--- a/CHANGES.ja.md
+++ b/CHANGES.ja.md
@@ -1,6 +1,22 @@
 変更点
 ======
 
+- `AuthleteApi` インターフェース
+    * `credentialIssuerMetadata(CredentialIssuerMetadataRequest)` メソッドを追加。
+
+- `MapUtils` クラス
+    * `putJsonArray(Map, String, String, boolean)` メソッドを追加。
+
+- `Service` クラス
+    * Added `getCredentialIssuerMetadata()` メソッドを追加。
+    * Added `setCredentialIssuerMetadata(CredentialIssuerMetadata)` メソッドを追加。
+
+- 新しい型
+    * `CredentialIssuerMetadata` クラス
+    * `CredentialIssuerMetadataRequest` クラス
+    * `CredentialIssuerMetadataResponse` クラス
+
+
 3.54 (2023 年 03 月 28 日)
 --------------------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,22 @@
 CHANGES
 =======
 
+- `AuthleteApi` interface
+    * Added `credentialIssuerMetadata(CredentialIssuerMetadataRequest)` method.
+
+- `MapUtils` class
+    * Added `putJsonArray(Map, String, String, boolean)` method.
+
+- `Service` class
+    * Added `getCredentialIssuerMetadata()` method.
+    * Added `setCredentialIssuerMetadata(CredentialIssuerMetadata)` method.
+
+- New types
+    * `CredentialIssuerMetadata` class
+    * `CredentialIssuerMetadataRequest` class
+    * `CredentialIssuerMetadataResponse` class
+
+
 3.54 (2023-03-28)
 -----------------
 

--- a/src/main/java/com/authlete/common/api/AuthleteApi.java
+++ b/src/main/java/com/authlete/common/api/AuthleteApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2022 Authlete, Inc.
+ * Copyright (C) 2014-2023 Authlete, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,8 @@ import com.authlete.common.dto.ClientRegistrationRequest;
 import com.authlete.common.dto.ClientRegistrationResponse;
 import com.authlete.common.dto.ClientSecretRefreshResponse;
 import com.authlete.common.dto.ClientSecretUpdateResponse;
+import com.authlete.common.dto.CredentialIssuerMetadataRequest;
+import com.authlete.common.dto.CredentialIssuerMetadataResponse;
 import com.authlete.common.dto.DeviceAuthorizationRequest;
 import com.authlete.common.dto.DeviceAuthorizationResponse;
 import com.authlete.common.dto.DeviceCompleteRequest;
@@ -1638,4 +1640,20 @@ public interface AuthleteApi
      */
     FederationRegistrationResponse federationRegistration(
             FederationRegistrationRequest request) throws AuthleteApiException;
+
+
+    /**
+     * Call Authlete's {@code /vci/metadata} API.
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 3.55
+     * @since Authlete 3.0
+     */
+    CredentialIssuerMetadataResponse credentialIssuerMetadata(
+            CredentialIssuerMetadataRequest request) throws AuthleteApiException;
 }

--- a/src/main/java/com/authlete/common/api/AuthleteApiImpl.java
+++ b/src/main/java/com/authlete/common/api/AuthleteApiImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2022 Authlete, Inc.
+ * Copyright (C) 2017-2023 Authlete, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,6 +57,8 @@ import com.authlete.common.dto.ClientRegistrationResponse;
 import com.authlete.common.dto.ClientSecretRefreshResponse;
 import com.authlete.common.dto.ClientSecretUpdateRequest;
 import com.authlete.common.dto.ClientSecretUpdateResponse;
+import com.authlete.common.dto.CredentialIssuerMetadataRequest;
+import com.authlete.common.dto.CredentialIssuerMetadataResponse;
 import com.authlete.common.dto.DeviceAuthorizationRequest;
 import com.authlete.common.dto.DeviceAuthorizationResponse;
 import com.authlete.common.dto.DeviceCompleteRequest;
@@ -188,6 +190,7 @@ class AuthleteApiImpl implements AuthleteApi
     private static final String CLIENT_LOCK_FLAG_UPDATE_API_PATH       = "/api/client/lock_flag/update";
     private static final String FEDERATION_CONFIGURATION_API_PATH      = "/api/federation/configuration";
     private static final String FEDERATION_REGISTRATION_API_PATH       = "/api/federation/registration";
+    private static final String VCI_METADATA_API_PATH                  = "/api/vci/metadata";
 
 
     private final String mBaseUrl;
@@ -1648,5 +1651,15 @@ class AuthleteApiImpl implements AuthleteApi
         return callServicePostApi(
                 FEDERATION_REGISTRATION_API_PATH, request,
                 FederationRegistrationResponse.class);
+    }
+
+
+    @Override
+    public CredentialIssuerMetadataResponse credentialIssuerMetadata(
+            CredentialIssuerMetadataRequest request) throws AuthleteApiException
+    {
+        return callServicePostApi(
+                VCI_METADATA_API_PATH, request,
+                CredentialIssuerMetadataResponse.class);
     }
 }

--- a/src/main/java/com/authlete/common/dto/CredentialIssuerMetadata.java
+++ b/src/main/java/com/authlete/common/dto/CredentialIssuerMetadata.java
@@ -1,0 +1,414 @@
+/*
+ * Copyright (C) 2023 Authlete, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.authlete.common.dto;
+
+
+import java.io.Serializable;
+import java.net.URI;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import static com.authlete.common.util.MapUtils.*;
+
+
+/**
+ * A class that represents the set of credential issuer metadata.
+ * The set consists of the following.
+ *
+ * <ul>
+ * <li>{@code credential_issuer}
+ * <li>{@code authorization_server}
+ * <li>{@code credential_endpoint}
+ * <li>{@code batch_credential_endpoint}
+ * <li>{@code credentials_supported}
+ * </ul>
+ *
+ * <p>
+ * A credential issuer announces these metadata at
+ * {@code /.well-known/openid-credential-issuer}.
+ * </p>
+ *
+ * @since 3.55
+ * @since Authlete 3.0
+ *
+ * @see <a href="https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html"
+ *      >OpenID for Verifiable Credential Issuance</a>
+ */
+public class CredentialIssuerMetadata implements Serializable
+{
+    private static final long serialVersionUID = 1L;
+
+
+    /**
+     * The identifier of the credential issuer.
+     */
+    private URI credentialIssuer;
+
+
+    /**
+     * The identifier of the authorization server that the credential issuer
+     * relies on for authorization.
+     */
+    private URI authorizationServer;
+
+
+    /**
+     * The URL of the credential endpoint of the credential issuer.
+     */
+    private URI credentialEndpoint;
+
+
+    /**
+     * The URL of the batch credential endpoint of the credential issuer.
+     */
+    private URI batchCredentialEndpoint;
+
+
+    /**
+     * A JSON array describing supported credentials.
+     */
+    private String credentialsSupported;
+
+
+    /**
+     * The default constructor.
+     */
+    public CredentialIssuerMetadata()
+    {
+    }
+
+
+    /**
+     * Copy constructor.
+     *
+     * @param metadata
+     *         Source to copy data from. {@code null} won't raise any exception.
+     */
+    public CredentialIssuerMetadata(CredentialIssuerMetadata metadata)
+    {
+        if (metadata == null)
+        {
+            return;
+        }
+
+        credentialIssuer        = metadata.getCredentialIssuer();
+        authorizationServer     = metadata.getAuthorizationServer();
+        credentialEndpoint      = metadata.getCredentialEndpoint();
+        batchCredentialEndpoint = metadata.getBatchCredentialEndpoint();
+        credentialsSupported    = metadata.getCredentialsSupported();
+    }
+
+
+    /**
+     * Get the identifier of the credential issuer. This property corresponds
+     * to the {@code credential_issuer} metadata.
+     *
+     * <p>
+     * To make the feature of credential issuance function, this property must
+     * be set.
+     * </p>
+     *
+     * @return
+     *         The identifier of the credential issuer.
+     */
+    public URI getCredentialIssuer()
+    {
+        return credentialIssuer;
+    }
+
+
+    /**
+     * Set the identifier of the credential issuer. This property corresponds
+     * to the {@code credential_issuer} metadata.
+     *
+     * <p>
+     * To make the feature of credential issuance function, this property must
+     * be set.
+     * </p>
+     *
+     * @param issuer
+     *         The identifier of the credential issuer.
+     *
+     * @return
+     *         {@code this} object.
+     */
+    public CredentialIssuerMetadata setCredentialIssuer(URI issuer)
+    {
+        this.credentialIssuer = issuer;
+
+        return this;
+    }
+
+
+    /**
+     * Get the identifier of the authorization server that the credential
+     * issuer relies on for authorization. This property corresponds to the
+     * {@code authorization_server} metadata.
+     *
+     * <p>
+     * When the credential issuer works as an authorization server for itself,
+     * this property should be omitted.
+     * </p>
+     *
+     * @return
+     *         The identifier of the authorization server that the credential
+     *         issuer relies on for authorization.
+     */
+    public URI getAuthorizationServer()
+    {
+        return authorizationServer;
+    }
+
+
+    /**
+     * Set the identifier of the authorization server that the credential
+     * issuer relies on for authorization. This property corresponds to the
+     * {@code authorization_server} metadata.
+     *
+     * <p>
+     * When the credential issuer works as an authorization server for itself,
+     * this property should be omitted.
+     * </p>
+     *
+     * @param server
+     *         The identifier of the authorization server that the credential
+     *         issuer relies on for authorization.
+     *
+     * @return
+     *         {@code this} object.
+     */
+    public CredentialIssuerMetadata setAuthorizationServer(URI server)
+    {
+        this.authorizationServer = server;
+
+        return this;
+    }
+
+
+    /**
+     * Get the URL of the credential endpoint. This property corresponds to the
+     * {@code credential_endpoint} metadata.
+     *
+     * <p>
+     * To make the feature of credential issuance function, this property must
+     * be set.
+     * </p>
+     *
+     * @return
+     *         The URL of the credential endpoint.
+     */
+    public URI getCredentialEndpoint()
+    {
+        return credentialEndpoint;
+    }
+
+
+    /**
+     * Set the URL of the credential endpoint. This property corresponds to the
+     * {@code credential_endpoint} metadata.
+     *
+     * <p>
+     * To make the feature of credential issuance function, this property must
+     * be set.
+     * </p>
+     *
+     * @param endpoint
+     *         The URL of the credential endpoint.
+     *
+     * @return
+     *         {@code this} object.
+     */
+    public CredentialIssuerMetadata setCredentialEndpoint(URI endpoint)
+    {
+        this.credentialEndpoint = endpoint;
+
+        return this;
+    }
+
+
+    /**
+     * Get the URL of the batch credential endpoint. This property corresponds
+     * to the {@code batch_credential_endpoint} metadata.
+     *
+     * <p>
+     * If the credential issuer does not support the batch credential endpoint,
+     * this property should be omitted.
+     * </p>
+     *
+     * @return
+     *         The URL of the batch credential endpoint.
+     */
+    public URI getBatchCredentialEndpoint()
+    {
+        return batchCredentialEndpoint;
+    }
+
+
+    /**
+     * Set the URL of the batch credential endpoint. This property corresponds
+     * to the {@code batch_credential_endpoint} metadata.
+     *
+     * <p>
+     * If the credential issuer does not support the batch credential endpoint,
+     * this property should be omitted.
+     * </p>
+     *
+     * @param endpoint
+     *         The URL of the batch credential endpoint.
+     *
+     * @return
+     */
+    public CredentialIssuerMetadata setBatchCredentialEndpoint(URI endpoint)
+    {
+        this.batchCredentialEndpoint = endpoint;
+
+        return this;
+    }
+
+
+    /**
+     * Get the information about supported credentials in the JSON format.
+     * This property corresponds to the {@code credentials_supported} metadata.
+     *
+     * <p>
+     * To make the feature of credential issuance function, this property must
+     * be set.
+     * </p>
+     *
+     * @return
+     *         The supported credentials. If not null, the value is a string
+     *         representing a JSON array.
+     */
+    public String getCredentialsSupported()
+    {
+        return credentialsSupported;
+    }
+
+
+    /**
+     * Set the information about supported credentials in the JSON format.
+     * This property corresponds to the {@code credentials_supported} metadata.
+     *
+     * <p>
+     * To make the feature of credential issuance function, this property must
+     * be set.
+     * </p>
+     *
+     * @param credentialsSupported
+     *         The supported credentials. If not null, the value must be a
+     *         string representing a JSON array.
+     *
+     * @return
+     *         {@code this} object.
+     */
+    public CredentialIssuerMetadata setCredentialsSupported(String credentialsSupported)
+    {
+        this.credentialsSupported = credentialsSupported;
+
+        return this;
+    }
+
+
+    /**
+     * Check if all properties of this instance are null.
+     *
+     * @return
+     *         {@code true} if all properties are null.
+     */
+    public boolean isEmpty()
+    {
+        return (credentialIssuer        == null) &&
+               (authorizationServer     == null) &&
+               (credentialEndpoint      == null) &&
+               (batchCredentialEndpoint == null) &&
+               (credentialsSupported    == null);
+    }
+
+
+    /**
+     * Create a {@code Map} instance that represents a JSON object conforming
+     * to the format of the credential issuer metadata defined in "OpenID for
+     * Verifiable Credential Issuance".
+     *
+     * <p>
+     * The following is an example of {@code Map} content.
+     * </p>
+     *
+     * <blockquote>
+     * <pre>
+     * {
+     *   "credential_issuer": "https://credential-issuer.example.com",
+     *   "authorization_server": "https://authorization-server.example.com",
+     *   "credential_endpoint": "https://credential-issuer.example.com/credential",
+     *   "batch_credential_endpoint": "https://credential-issuer.example.com/batch_credential",
+     *   "credentials_supported": [
+     *     {
+     *       "format": "jwt_vc_json",
+     *       "id": "UniversityDegree_JWT",
+     *       "type": [
+     *         "VerifiableCredential",
+     *         "UniversityDegreeCredential"
+     *       ],
+     *       "cryptographic_binding_methods_supported": [
+     *         "did:example"
+     *       ],
+     *       "cryptographic_suites_supported": [
+     *         "ES256K"
+     *       ],
+     *       "display": [
+     *         "name": "University Credential"
+     *       ],
+     *       "credentialSubject": {
+     *         "given_name": {},
+     *         "last_name": {},
+     *         "degree": {}
+     *       }
+     *     }
+     *   ]
+     * }
+     * </pre>
+     * </blockquote>
+     *
+     * @return
+     *         A {@code Map} instance that represents a JSON object conforming
+     *         to the format of the credential issuer metadata.
+     *
+     * @throws IllegalStateException
+     *         The value of the {@code credentialsSupported} property failed
+     *         to be parsed as a JSON array.
+     */
+    public Map<String, Object> toMap()
+    {
+        Map<String, Object> map = new LinkedHashMap<>();
+
+        put(map, "credential_issuer",         credentialIssuer,        false);
+        put(map, "authorization_server",      authorizationServer,     false);
+        put(map, "credential_endpoint",       credentialEndpoint,      false);
+        put(map, "batch_credential_endpoint", batchCredentialEndpoint, false);
+
+        try
+        {
+            // Parse the value of 'credentialsSupported' as a JSON array.
+            putJsonArray(map, "credentials_supported", credentialsSupported, false);
+        }
+        catch (Exception cause)
+        {
+            throw new IllegalStateException(
+                    "The value of the 'credentialsSupported' property failed to be parsed as a JSON array.", cause);
+        }
+
+        return map;
+    }
+}

--- a/src/main/java/com/authlete/common/dto/CredentialIssuerMetadataRequest.java
+++ b/src/main/java/com/authlete/common/dto/CredentialIssuerMetadataRequest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2023 Authlete, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.authlete.common.dto;
+
+
+import java.io.Serializable;
+
+
+/**
+ * Request to Authlete's {@code /vci/metadata} API.
+ *
+ * <p>
+ * The Authlete API is supposed to be used from within the implementation of
+ * the credential issuer metadata endpoint
+ * ({@code /.well-known/openid-credential-issuer}).
+ * </p>
+ *
+ * @since 3.55
+ * @since Authlete 3.0
+ *
+ * @see <a href="https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html"
+ *      >OpenID for Verifiable Credential Issuance</a>
+ */
+public class CredentialIssuerMetadataRequest implements Serializable
+{
+    private static final long serialVersionUID = 1L;
+}

--- a/src/main/java/com/authlete/common/dto/CredentialIssuerMetadataResponse.java
+++ b/src/main/java/com/authlete/common/dto/CredentialIssuerMetadataResponse.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright (C) 2023 Authlete, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.authlete.common.dto;
+
+
+/**
+ * Response from Authlete's {@code /vci/metadata} API.
+ *
+ * <p>
+ * The Authlete API is supposed to be used from within the implementation of
+ * the credential issuer metadata endpoint
+ * ({@code /.well-known/openid-credential-issuer}).
+ * </p>
+ *
+ * <p>
+ * Authlete's {@code /vci/metadata} API returns JSON which can be mapped to
+ * this class. The credential issuer implementation should retrieve the value
+ * of the <code>{@link #getAction() action}</code> response parameter from
+ * the API response and take the following steps according to the value.
+ * </p>
+ *
+ * <h3><code>OK</code></h3>
+ *
+ * <p>
+ * When the value of the <code>{@link #getAction() action}</code> response
+ * parameter is <code>{@link Action#OK OK}</code>, it means that Authlete
+ * could prepare credential issuer metadata successfully.
+ * <p>
+ *
+ * </p>
+ * In this case, the implementation of the credential issuer metadata endpoint
+ * ({@code /.well-known/openid-credential-issuer}) of the credential issuer
+ * should return an HTTP response with the HTTP status code "{@code 200 OK}"
+ * and the content type "{@code application/json}". The message body of the
+ * response has been prepared by Authlete's {@code /vci/metadata} API and it
+ * is available as the <code>{@link #getResponseContent() responseContent}</code>
+ * response parameter.
+ * </p>
+ *
+ * <p>
+ * The implementation of the credential issuer metadata endpoint can construct
+ * an HTTP response by doing like below.
+ * </p>
+ *
+ * <pre style="border: solid 1px black; padding: 0.5em;">
+ * 200 OK
+ * Content-Type: application/json
+ * (Other HTTP headers)
+ *
+ * <i>(the value of the {@link #getResponseContent() responseContent} response parameter)</i></pre>
+ *
+ * <h3><code>NOT_FOUND</code></h3>
+ *
+ * <p>
+ * When the value of the <code>{@link #getAction() action}</code> response
+ * parameter is <code>{@link Action#NOT_FOUND NOT_FOUND}</code>, it means that
+ * the service configuration has not enabled the feature of Verifiable
+ * Credentials and so the credential issuer metadata endpoint should not be
+ * accessed.
+ * </p>
+ *
+ * </p>
+ * In this case, the implementation of the credential issuer metadata endpoint
+ * of the credential issuer should return an HTTP response with the HTTP status
+ * code "{@code 404 Not Found}" and the content type "{@code application/json}".
+ * The message body (= error information in the JSON format) of the response
+ * has been prepared by Authlete's {@code /vci/metadata} API and it is available
+ * as the <code>{@link #getResponseContent() responseContent}</code> response
+ * parameter.
+ * </p>
+ *
+ * <p>
+ * The implementation of the credential issuer metadata endpoint can construct
+ * an HTTP response by doing like below.
+ * </p>
+ *
+ * <pre style="border: solid 1px black; padding: 0.5em;">
+ * 404 Not Found
+ * Content-Type: application/json
+ * (Other HTTP headers)
+ *
+ * <i>(the value of the {@link #getResponseContent() responseContent} response parameter)</i></pre>
+ *
+ * <h3><code>INTERNAL_SERVER_ERROR</code></h3>
+ *
+ * <p>
+ * When the value of the <code>{@link #getAction() action}</code> response
+ * parameter is <code>{@link Action#INTERNAL_SERVER_ERROR INTERNAL_SERVER_ERROR}</code>,
+ * it means that an unexpected error has occurred on Authlete side or the
+ * service has not been set up properly yet.
+ * </p>
+ *
+ * </p>
+ * In this case, a simple implementation of the credential issuer metadata
+ * endpoint would return an HTTP response with the HTTP status code
+ * "{@code 500 Internal Server Error}" and the content type
+ * "{@code application/json}". The message body (= error information in the JSON
+ * format) of the response has been prepared by Authlete's {@code /vci/metadata}
+ * API and it is available as the <code>{@link #getResponseContent()
+ * responseContent}</code> response parameter.
+ * </p>
+ *
+ * <p>
+ * Such simple implementation of the credential issuer metadata endpoint can
+ * construct an HTTP response by doing like below.
+ * </p>
+ *
+ * <pre style="border: solid 1px black; padding: 0.5em;">
+ * 500 Internal Server Error
+ * Content-Type: application/json
+ * (Other HTTP headers)
+ *
+ * <i>(the value of the {@link #getResponseContent() responseContent} response parameter)</i></pre>
+ *
+ * <p>
+ * However, in real commercial deployments, it is rare for a credential issuer
+ * to return "{@code 500 Internal Server Error}" when it encounters an
+ * unexpected internal error. It's up to implementations of credential issuers
+ * what they actually return in the case of internal server error.
+ * </p>
+ *
+ * @since 3.55
+ * @since Authlete 3.0
+ *
+ * @see <a href="https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html"
+ *      >OpenID for Verifiable Credential Issuance</a>
+ */
+public class CredentialIssuerMetadataResponse extends ApiResponse
+{
+    private static final long serialVersionUID = 1L;
+
+
+    /**
+     * The next action that the implementation of the credential issuer
+     * metadata endpoint ({@code /.well-known/openid-credential-issuer})
+     * should take after getting a response from Authlete's
+     * {@code /vci/metadata} API.
+     *
+     * @since 3.55
+     * @since Authlete 3.0
+     */
+    public enum Action
+    {
+        /**
+         * Credential issuer metadata has been prepared successfully. The
+         * implementation of the credential issuer metadata endpoint should
+         * return an HTTP response with the HTTP status code "{@code 200 OK}"
+         * and the content type "{@code application/json}".
+         */
+        OK,
+
+        /**
+         * The feature of Verifiable Credentials is not enabled. The
+         * implementation of the credential issuer metadata endpoint should
+         * return an HTTP response with the HTTP status code
+         * "{@code 404 Not Found}" and the content type
+         * "{@code application/json}" to indicate that the endpoint should
+         * not be accessed.
+         */
+        NOT_FOUND,
+
+        /**
+         * An unexpected error occurred on Authlete side or the service has
+         * not been set up properly yet. A simple implementation of the
+         * credential issuer metadata endpoint would return an HTTP response
+         * with the HTTP status code "{@code 500 Internal Server Error}" and
+         * the content type "{@code application/json}".
+         */
+        INTERNAL_SERVER_ERROR,
+    }
+
+
+    private Action action;
+    private String responseContent;
+
+
+    /**
+     * Get the next action that the implementation of the credential issuer
+     * metadata endpoint should take after getting a response from Authlete's
+     * {@code /vci/metadata} API.
+     *
+     * @return
+     *         The next action.
+     */
+    public Action getAction()
+    {
+        return action;
+    }
+
+
+    /**
+     * Set the next action that the implementation of the credential issuer
+     * metadata endpoint should take after getting a response from Authlete's
+     * {@code /vci/metadata} API.
+     *
+     * @param action
+     *         The next action.
+     *
+     * @return
+     *         {@code this} object.
+     */
+    public CredentialIssuerMetadataResponse setAction(Action action)
+    {
+        this.action = action;
+
+        return this;
+    }
+
+
+    /**
+     * Get the content that the implementation of the credential issuer
+     * metadata endpoint should use when it constructs a response.
+     *
+     * @return
+     *         The response content in the JSON format.
+     */
+    public String getResponseContent()
+    {
+        return responseContent;
+    }
+
+
+    /**
+     * Set the content that the implementation of the credential issuer
+     * metadata endpoint should use when it constructs a response.
+     *
+     * @param content
+     *         The response content in the JSON format.
+     *
+     * @return
+     *         {@code this} object.
+     */
+    public CredentialIssuerMetadataResponse setResponseContent(String content)
+    {
+        this.responseContent = content;
+
+        return this;
+    }
+}

--- a/src/main/java/com/authlete/common/dto/Service.java
+++ b/src/main/java/com/authlete/common/dto/Service.java
@@ -327,7 +327,7 @@ import com.authlete.common.types.UserCodeCharset;
  */
 public class Service implements Serializable
 {
-    private static final long serialVersionUID = 63L;
+    private static final long serialVersionUID = 64L;
 
 
     /*
@@ -1350,6 +1350,25 @@ public class Service implements Serializable
      * @since Authlete 2.2.36
      */
     private boolean openidDroppedOnRefreshWithoutOfflineAccess;
+
+
+    /**
+     * The flag indicating whether the feature of Verifiable Credentials for
+     * this service is enabled or not.
+     *
+     * @since 3.55
+     * @since Authlete 3.0
+     */
+    private boolean verifiableCredentialsEnabled;
+
+
+    /**
+     * Credential issuer metadata.
+     *
+     * @since 3.55
+     * @since Authlete 3.0
+     */
+    private CredentialIssuerMetadata credentialIssuerMetadata;
 
 
     /**
@@ -9990,6 +10009,85 @@ public class Service implements Serializable
     public Service setOpenidDroppedOnRefreshWithoutOfflineAccess(boolean dropped)
     {
         this.openidDroppedOnRefreshWithoutOfflineAccess = dropped;
+
+        return this;
+    }
+
+
+    /**
+     * Get the flag indicating whether the feature of Verifiable Credentials
+     * for this service is enabled or not.
+     *
+     * @return
+     *         {@code true} if the feature of Verifiable Credentials is enabled.
+     *
+     * @since 3.55
+     * @since Authlete 3.0
+     */
+    public boolean isVerifiableCredentialsEnabled()
+    {
+        return verifiableCredentialsEnabled;
+    }
+
+
+    /**
+     * Set the flag indicating whether the feature of Verifiable Credentials
+     * for this service is enabled or not.
+     *
+     * @param enabled
+     *         {@code true} to indicate that the feature of Verifiable Credentials
+     *         is enabled.
+     *
+     * @return
+     *         {@code this} object.
+     *
+     * @since 3.55
+     * @since Authlete 3.0
+     */
+    public Service setVerifiableCredentialsEnabled(boolean enabled)
+    {
+        this.verifiableCredentialsEnabled = enabled;
+
+        return this;
+    }
+
+
+    /**
+     * Get the credential issuer metadata.
+     *
+     * @return
+     *         The credential issuer metadata.
+     *
+     * @since 3.55
+     * @since Authlete 3.0
+     *
+     * @see <a href="https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html"
+     *      >OpenID for Verifiable Credential Issuance</a>
+     */
+    public CredentialIssuerMetadata getCredentialIssuerMetadata()
+    {
+        return credentialIssuerMetadata;
+    }
+
+
+    /**
+     * Set the credential issuer metadata.
+     *
+     * @param metadata
+     *         The credential issuer metadata.
+     *
+     * @return
+     *         {@code this} object.
+     *
+     * @since 3.55
+     * @since Authlete 3.0
+     *
+     * @see <a href="https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html"
+     *      >OpenID for Verifiable Credential Issuance</a>
+     */
+    public Service setCredentialIssuerMetadata(CredentialIssuerMetadata metadata)
+    {
+        this.credentialIssuerMetadata = metadata;
 
         return this;
     }

--- a/src/main/java/com/authlete/common/util/MapUtils.java
+++ b/src/main/java/com/authlete/common/util/MapUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Authlete, Inc.
+ * Copyright (C) 2022-2023 Authlete, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -188,6 +188,31 @@ public class MapUtils
     {
         Map<String, Object> value = (json == null) ? null :
                 (Map<String, Object>)Utils.fromJson(json, Map.class);
+
+        if (value != null || nullIncluded)
+        {
+            target.put(key, value);
+        }
+    }
+
+
+    /**
+     * Convert the given {@code json} into a {@code List} instance and put
+     * the instance into the {@code target} map with the {@code key}.
+     *
+     * <p>
+     * If {@code nullIncluded} is {@code true}, the {@code key} is put into
+     * the {@code target} map even when the given {@code json} is {@code null}.
+     * </p>
+     *
+     * @since 3.55
+     */
+    public static void putJsonArray(
+            Map<String, Object> target, String key,
+            String json, boolean nullIncluded)
+    {
+        List<?> value = (json == null) ? null :
+            (List<?>)Utils.fromJson(json, List.class);
 
         if (value != null || nullIncluded)
         {


### PR DESCRIPTION
To add the `CredentialIssuerMetadata` class that represents the set of the credential issuer metadata defined in the "OpenID for Verifiable Credential Issuance" specification.

To add some classes and methods for the `/vci/metadata` API that is for implementations of the credential issuer metadata endpoint (`/.well-known/openid-credential-issuer`).