### PR TITLE
[feature] JWT Issuer Metadata

### DIFF
--- a/CHANGES.ja.md
+++ b/CHANGES.ja.md
@@ -1,6 +1,18 @@
 変更点
 ======
 
+- `AuthleteApi` インターフェース
+    * `credentialJwtIssuerMetadata(CredentialJwtIssuerMetadataRequest)` メソッドを追加。
+
+- `Service` クラス
+    * `getCredentialJwksUri()` メソッドを追加。
+    * `setCredentialJwksUri(URI)` メソッドを追加。
+
+- 新しい型
+    * `CredentialJwtIssuerMetadataRequest` クラス
+    * `CredentialJwtIssuerMetadataResponse` クラス
+
+
 3.78 (2023 年 09 月 16 日)
 --------------------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,18 @@
 CHANGES
 =======
 
+- `AuthleteApi` interface
+    * Added `credentialJwtIssuerMetadata(CredentialJwtIssuerMetadataRequest)` method.
+
+- `Service` class
+    * Added `getCredentialJwksUri()` method.
+    * Added `setCredentialJwksUri(URI)` method.
+
+- New types
+    * `CredentialJwtIssuerMetadataRequest` class
+    * `CredentialJwtIssuerMetadataResponse` class
+
+
 3.78 (2023-09-16)
 -----------------
 
@@ -84,7 +96,7 @@ CHANGES
 - `ClientAuthMethod` enum
     * Added `ATTEST_JWT_CLIENT_AUTH`.
 
-- New Types
+- New types
     * `ClientAssertionType` enum
 
 

--- a/src/main/java/com/authlete/common/api/AuthleteApi.java
+++ b/src/main/java/com/authlete/common/api/AuthleteApi.java
@@ -52,6 +52,8 @@ import com.authlete.common.dto.CredentialIssuerJwksRequest;
 import com.authlete.common.dto.CredentialIssuerJwksResponse;
 import com.authlete.common.dto.CredentialIssuerMetadataRequest;
 import com.authlete.common.dto.CredentialIssuerMetadataResponse;
+import com.authlete.common.dto.CredentialJwtIssuerMetadataRequest;
+import com.authlete.common.dto.CredentialJwtIssuerMetadataResponse;
 import com.authlete.common.dto.CredentialOfferCreateRequest;
 import com.authlete.common.dto.CredentialOfferCreateResponse;
 import com.authlete.common.dto.CredentialOfferInfoRequest;
@@ -1676,6 +1678,22 @@ public interface AuthleteApi
      */
     CredentialIssuerMetadataResponse credentialIssuerMetadata(
             CredentialIssuerMetadataRequest request) throws AuthleteApiException;
+
+
+    /**
+     * Call Authlete's {@code /vci/jwtissuer} API.
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 3.79
+     * @since Authlete 3.0
+     */
+    CredentialJwtIssuerMetadataResponse credentialJwtIssuerMetadata(
+            CredentialJwtIssuerMetadataRequest request) throws AuthleteApiException;
 
 
     /**

--- a/src/main/java/com/authlete/common/api/AuthleteApiImpl.java
+++ b/src/main/java/com/authlete/common/api/AuthleteApiImpl.java
@@ -69,6 +69,8 @@ import com.authlete.common.dto.CredentialIssuerJwksRequest;
 import com.authlete.common.dto.CredentialIssuerJwksResponse;
 import com.authlete.common.dto.CredentialIssuerMetadataRequest;
 import com.authlete.common.dto.CredentialIssuerMetadataResponse;
+import com.authlete.common.dto.CredentialJwtIssuerMetadataRequest;
+import com.authlete.common.dto.CredentialJwtIssuerMetadataResponse;
 import com.authlete.common.dto.CredentialOfferCreateRequest;
 import com.authlete.common.dto.CredentialOfferCreateResponse;
 import com.authlete.common.dto.CredentialOfferInfoRequest;
@@ -211,6 +213,7 @@ class AuthleteApiImpl implements AuthleteApi
     private static final String FEDERATION_CONFIGURATION_API_PATH      = "/api/federation/configuration";
     private static final String FEDERATION_REGISTRATION_API_PATH       = "/api/federation/registration";
     private static final String VCI_METADATA_API_PATH                  = "/api/vci/metadata";
+    private static final String VCI_JWT_ISSUER_API_PATH                = "/api/vci/jwtissuer";
     private static final String VCI_JWKS_API_PATH                      = "/api/vci/jwks";
     private static final String VCI_OFFER_CREATE_API_PATH              = "/api/vci/offer/create";
     private static final String VCI_OFFER_INFO_API_PATH                = "/api/vci/offer/info";
@@ -1693,6 +1696,18 @@ class AuthleteApiImpl implements AuthleteApi
         return callServicePostApi(
                 VCI_METADATA_API_PATH, request,
                 CredentialIssuerMetadataResponse.class);
+    }
+
+
+    @Override
+    public CredentialJwtIssuerMetadataResponse credentialJwtIssuerMetadata(
+            CredentialJwtIssuerMetadataRequest request) throws AuthleteApiException
+    {
+        // This API call fails because the /vci/jwtissuer API is unavailable
+        // in Authlete 2.x and older versions.
+        return callServicePostApi(
+                VCI_JWT_ISSUER_API_PATH, request,
+                CredentialJwtIssuerMetadataResponse.class);
     }
 
 

--- a/src/main/java/com/authlete/common/dto/CredentialJwtIssuerMetadataRequest.java
+++ b/src/main/java/com/authlete/common/dto/CredentialJwtIssuerMetadataRequest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2023 Authlete, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.authlete.common.dto;
+
+
+import java.io.Serializable;
+
+
+/**
+ * Request to Authlete's {@code /vci/jwtissuer} API.
+ *
+ * <p>
+ * The Authlete API is supposed to be called from within the implementation of
+ * the JWT issuer metadata endpoint ({@code /.well-known/jwt-issuer}) of the
+ * credential issuer.
+ * </p>
+ *
+ * <p>
+ * The API will generate JSON like below.
+ * </p>
+ *
+ * <blockquote>
+ * <pre>
+ * {
+ *   "issuer": "{@link Service}.{@link Service#getCredentialIssuerMetadata()
+ *              getCredentialIssuerMetadata()}.{@link CredentialIssuerMetadata#getCredentialIssuer()
+ *              getCredentialIssuer()}",
+ *   "jwks_uri": "{@link Service}.{@link Service#getCredentialJwksUri()
+ *              getCredentialJwksUri()}"
+ * }
+ * </pre>
+ * </blockquote>
+ *
+ * <p>
+ * Note that the JWT issuer metadata endpoint ({@code /.well-known/jwt-issuer})
+ * is different from the credential issuer metadata endpoint
+ * ({@code /.well-known/openid-credential-issuer}).
+ * </p>
+ *
+ * @since 3.79
+ * @since Authlete 3.0
+ *
+ * @see CredentialJwtIssuerMetadataResponse
+ * @see <a href="https://datatracker.ietf.org/doc/draft-ietf-oauth-sd-jwt-vc/"
+ *      >SD-JWT-based Verifiable Credentials (SD-JWT VC)</a>
+ */
+public class CredentialJwtIssuerMetadataRequest implements Serializable
+{
+    private static final long serialVersionUID = 1L;
+
+
+    private boolean pretty;
+
+
+    /**
+     * Get the flag indicating whether the metadata is written in the pretty
+     * format or not.
+     *
+     * @return
+     *         {@code true} if the metadata is written in the pretty format.
+     */
+    public boolean isPretty()
+    {
+        return pretty;
+    }
+
+
+    /**
+     * Set the flag indicating whether the metadata is written in the pretty
+     * format or not.
+     *
+     * @param pretty
+     *         {@code true} to write the metadata in the pretty format.
+     *
+     * @return
+     *         {@code this} object.
+     */
+    public CredentialJwtIssuerMetadataRequest setPretty(boolean pretty)
+    {
+        this.pretty = pretty;
+
+        return this;
+    }
+}

--- a/src/main/java/com/authlete/common/dto/CredentialJwtIssuerMetadataResponse.java
+++ b/src/main/java/com/authlete/common/dto/CredentialJwtIssuerMetadataResponse.java
@@ -1,0 +1,282 @@
+/*
+ * Copyright (C) 2023 Authlete, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.authlete.common.dto;
+
+
+/**
+ * Response from Authlete's {@code /vci/jwtissuer} API.
+ *
+ * <p>
+ * The Authlete API is supposed to be called from within the implementation of
+ * the JWT issuer metadata endpoint ({@code /.well-known/jwt-issuer}) of the
+ * credential issuer.
+ * </p>
+ *
+ * <p>
+ * Authlete's {@code /vci/jwtissuer} API returns JSON which can be mapped to
+ * this class. The credential issuer implementation should retrieve the value
+ * of the <code>{@link #getAction() action}</code> response parameter from
+ * the API response and take the following steps according to the value.
+ * </p>
+ *
+ * <h3><code>OK</code></h3>
+ *
+ * <p>
+ * When the value of the <code>{@link #getAction() action}</code> response
+ * parameter is <code>{@link Action#OK OK}</code>, it means that Authlete
+ * could prepare the metadata successfully.
+ * <p>
+ *
+ * </p>
+ * In this case, the implementation of the JWT issuer metadata endpoint
+ * ({@code /.well-known/jwt-issuer}) of the credential issuer should return
+ * an HTTP response with the HTTP status code "{@code 200 OK}" and the content
+ * type "{@code application/json}". The message body of the response has been
+ * prepared by Authlete's {@code /vci/jwtissuer} API and it is available as
+ * the <code>{@link #getResponseContent() responseContent}</code> response
+ * parameter.
+ * </p>
+ *
+ * <p>
+ * The implementation of the JWT issuer metadata endpoint can construct an
+ * HTTP response by doing like below.
+ * </p>
+ *
+ * <pre style="border: solid 1px black; padding: 0.5em;">
+ * 200 OK
+ * Content-Type: application/json
+ * (Other HTTP headers)
+ *
+ * <i>(the value of the {@link #getResponseContent() responseContent} response parameter)</i></pre>
+ *
+ * <h3><code>NOT_FOUND</code></h3>
+ *
+ * <p>
+ * When the value of the <code>{@link #getAction() action}</code> response
+ * parameter is <code>{@link Action#NOT_FOUND NOT_FOUND}</code>, it means
+ * that the service configuration has not enabled the feature of Verifiable
+ * Credentials and so the JWT issuer metadata endpoint should not be accessed.
+ * </p>
+ *
+ * </p>
+ * In this case, the implementation of the JWT issuer metadata endpoint of the
+ * credential issuer should return an HTTP response with the HTTP status code
+ * "{@code 404 Not Found}" and the content type "{@code application/json}".
+ * The message body (= error information in the JSON format) of the response
+ * has been prepared by Authlete's {@code /vci/jwtissuer} API and it is available
+ * as the <code>{@link #getResponseContent() responseContent}</code> response
+ * parameter.
+ * </p>
+ *
+ * <p>
+ * The implementation of the JWT issuer metadata endpoint can construct an HTTP
+ * response by doing like below.
+ * </p>
+ *
+ * <pre style="border: solid 1px black; padding: 0.5em;">
+ * 404 Not Found
+ * Content-Type: application/json
+ * (Other HTTP headers)
+ *
+ * <i>(the value of the {@link #getResponseContent() responseContent} response parameter)</i></pre>
+ *
+ * <h3><code>INTERNAL_SERVER_ERROR</code></h3>
+ *
+ * <p>
+ * When the value of the <code>{@link #getAction() action}</code> response
+ * parameter is <code>{@link Action#INTERNAL_SERVER_ERROR INTERNAL_SERVER_ERROR}</code>,
+ * it means that an unexpected error has occurred on Authlete side or the
+ * service has not been set up properly yet.
+ * </p>
+ *
+ * </p>
+ * In this case, a simple implementation of the JWT issuer metadata endpoint
+ * would return an HTTP response with the HTTP status code
+ * "{@code 500 Internal Server Error}" and the content type
+ * "{@code application/json}". The message body (= error information in the
+ * JSON format) of the response has been prepared by Authlete's
+ * {@code /vci/jwtissuer} API and it is available as the
+ * <code>{@link #getResponseContent() responseContent}</code> response parameter.
+ * </p>
+ *
+ * <p>
+ * Such simple implementation of the JWT issuer metadata endpoint can construct
+ * an HTTP response by doing like below.
+ * </p>
+ *
+ * <pre style="border: solid 1px black; padding: 0.5em;">
+ * 500 Internal Server Error
+ * Content-Type: application/json
+ * (Other HTTP headers)
+ *
+ * <i>(the value of the {@link #getResponseContent() responseContent} response parameter)</i></pre>
+ *
+ * <p>
+ * However, in real commercial deployments, it is rare for a credential issuer
+ * to return "{@code 500 Internal Server Error}" when it encounters an
+ * unexpected internal error. It's up to implementations of credential issuers
+ * what they actually return in the case of internal server error.
+ * </p>
+ *
+ * @since 3.79
+ * @since Authlete 3.0
+ *
+ * @see CredentialJwtIssuerMetadataRequest
+ * @see <a href="https://datatracker.ietf.org/doc/draft-ietf-oauth-sd-jwt-vc/"
+ *      >SD-JWT-based Verifiable Credentials (SD-JWT VC)</a>
+ */
+public class CredentialJwtIssuerMetadataResponse extends ApiResponse
+{
+    private static final long serialVersionUID = 1L;
+
+
+    /**
+     * The next action that the implementation of the JWT issuer metadata
+     * endpoint ({@code /.well-known/jwt-issuer}) should take after getting
+     * a response from Authlete's {@code /vci/jwtissuer} API.
+     *
+     * @since 3.79
+     * @since Authlete 3.0
+     */
+    public enum Action
+    {
+        /**
+         * JWT issuer metadata has been prepared successfully. The
+         * implementation of the JWT issuer metadata endpoint should return
+         * an HTTP response with the HTTP status code "{@code 200 OK}" and
+         * the content type "{@code application/json}".
+         */
+        OK,
+
+        /**
+         * The feature of Verifiable Credentials is not enabled. The
+         * implementation of the JWT issuer metadata endpoint should return
+         * an HTTP response with the HTTP status code "{@code 404 Not Found}"
+         * and the content type "{@code application/json}" to indicate that
+         * the endpoint should not be accessed.
+         */
+        NOT_FOUND,
+
+        /**
+         * An unexpected error occurred on Authlete side or the service has
+         * not been set up properly yet. A simple implementation of the JWT
+         * issuer metadata endpoint would return an HTTP response with the
+         * HTTP status code "{@code 500 Internal Server Error}" and the
+         * content type "{@code application/json}".
+         */
+        INTERNAL_SERVER_ERROR,
+    }
+
+
+    private Action action;
+    private String responseContent;
+
+
+    /**
+     * Get the next action that the implementation of the JWT issuer metadata
+     * endpoint should take after getting a response from Authlete's
+     * {@code /vci/jwtissuer} API.
+     *
+     * @return
+     *         The next action.
+     */
+    public Action getAction()
+    {
+        return action;
+    }
+
+
+    /**
+     * Set the next action that the implementation of the JWT issuer metadata
+     * endpoint should take after getting a response from Authlete's
+     * {@code /vci/jwtissuer} API.
+     *
+     * @param action
+     *         The next action.
+     *
+     * @return
+     *         {@code this} object.
+     */
+    public CredentialJwtIssuerMetadataResponse setAction(Action action)
+    {
+        this.action = action;
+
+        return this;
+    }
+
+
+    /**
+     * Get the content that the implementation of the JWT issuer metadata
+     * endpoint should use when it constructs a response.
+     *
+     * <p>
+     * In the successful case, the content is JSON like below.
+     * </p>
+     *
+     * <blockquote>
+     * <pre>
+     * {
+     *   "issuer": "{@link Service}.{@link Service#getCredentialIssuerMetadata()
+     *              getCredentialIssuerMetadata()}.{@link CredentialIssuerMetadata#getCredentialIssuer()
+     *              getCredentialIssuer()}",
+     *   "jwks_uri": "{@link Service}.{@link Service#getCredentialJwksUri()
+     *              getCredentialJwksUri()}"
+     * }
+     * </pre>
+     * </blockquote>
+     *
+     * @return
+     *         The response content in the JSON format.
+     */
+    public String getResponseContent()
+    {
+        return responseContent;
+    }
+
+
+    /**
+     * Set the content that the implementation of the JWT issuer metadata
+     * endpoint should use when it constructs a response.
+     *
+     * <p>
+     * In the successful case, the content should be JSON like below.
+     * </p>
+     *
+     * <blockquote>
+     * <pre>
+     * {
+     *   "issuer": "{@link Service}.{@link Service#getCredentialIssuerMetadata()
+     *              getCredentialIssuerMetadata()}.{@link CredentialIssuerMetadata#getCredentialIssuer()
+     *              getCredentialIssuer()}",
+     *   "jwks_uri": "{@link Service}.{@link Service#getCredentialJwksUri()
+     *              getCredentialJwksUri()}"
+     * }
+     * </pre>
+     * </blockquote>
+     *
+     * @param content
+     *         The response content in the JSON format.
+     *
+     * @return
+     *         {@code this} object.
+     */
+    public CredentialJwtIssuerMetadataResponse setResponseContent(String content)
+    {
+        this.responseContent = content;
+
+        return this;
+    }
+}

--- a/src/main/java/com/authlete/common/dto/Service.java
+++ b/src/main/java/com/authlete/common/dto/Service.java
@@ -334,7 +334,7 @@ import com.authlete.common.types.UserCodeCharset;
  */
 public class Service implements Serializable
 {
-    private static final long serialVersionUID = 75L;
+    private static final long serialVersionUID = 76L;
 
 
     /*
@@ -1471,6 +1471,15 @@ public class Service implements Serializable
      * @since Authlete 3.0
      */
     private String credentialJwks;
+
+
+    /**
+     * The URL at which the JWK Set document of the credential issuer is exposed.
+     *
+     * @since 3.79
+     * @since Authlete 3.0
+     */
+    private URI credentialJwksUri;
 
 
     /**
@@ -11034,6 +11043,83 @@ public class Service implements Serializable
     public Service setCredentialJwks(String jwks)
     {
         this.credentialJwks = jwks;
+
+        return this;
+    }
+
+
+    /**
+     * Get the URL at which the JWK Set document of the credential issuer is
+     * exposed.
+     *
+     * <p>
+     * The value of this property is referenced when Authlete's
+     * {@code /vci/jwtissuer} API generates the JSON representing the JWT
+     * issuer metadata. The JSON will be generated like below.
+     * </p>
+     *
+     * <blockquote>
+     * <pre>
+     * {
+     *   "issuer": "{@link Service#getCredentialIssuerMetadata()
+     *              getCredentialIssuerMetadata()}.{@link CredentialIssuerMetadata#getCredentialIssuer()
+     *              getCredentialIssuer()}",
+     *   "jwks_uri": "{@link Service#getCredentialJwksUri() getCredentialJwksUri()}"
+     * }
+     * </pre>
+     * </blockquote>
+     *
+     * @return
+     *         The URL at which the JWK Set document of the credential issuer
+     *         is exposed.
+     *
+     * @since 3.79
+     * @since Authlete 3.0
+     *
+     * @see com.authlete.common.api.AuthleteApi#credentialJwtIssuerMetadata(CredentialJwtIssuerMetadataRequest)
+     */
+    public URI getCredentialJwksUri()
+    {
+        return credentialJwksUri;
+    }
+
+
+    /**
+     * Set the URL at which the JWK Set document of the credential issuer is
+     * exposed.
+     *
+     * <p>
+     * The value of this property is referenced when Authlete's
+     * {@code /vci/jwtissuer} API generates the JSON representing the JWT
+     * issuer metadata. The JSON will be generated like below.
+     * </p>
+     *
+     * <blockquote>
+     * <pre>
+     * {
+     *   "issuer": "{@link Service#getCredentialIssuerMetadata()
+     *              getCredentialIssuerMetadata()}.{@link CredentialIssuerMetadata#getCredentialIssuer()
+     *              getCredentialIssuer()}",
+     *   "jwks_uri": "{@link Service#getCredentialJwksUri() getCredentialJwksUri()}"
+     * }
+     * </pre>
+     * </blockquote>
+     *
+     * @param uri
+     *         The URL at which the JWK Set document of the credential issuer
+     *         is exposed.
+     *
+     * @return
+     *         {@code this} object.
+     *
+     * @since 3.79
+     * @since Authlete 3.0
+     *
+     * @see com.authlete.common.api.AuthleteApi#credentialJwtIssuerMetadata(CredentialJwtIssuerMetadataRequest)
+     */
+    public Service setCredentialJwksUri(URI uri)
+    {
+        this.credentialJwksUri = uri;
 
         return this;
     }


### PR DESCRIPTION
- `AuthleteApi` interface
    - Added `credentialJwtIssuerMetadata(CredentialJwtIssuerMetadataRequest)` method.

- `Service` class
    - Added `getCredentialJwksUri()` method.
    - Added `setCredentialJwksUri(URI)` method.

- New types
    - `CredentialJwtIssuerMetadataRequest` class
    - `CredentialJwtIssuerMetadataResponse` class