### PR TITLE
Addition of `refreshTokenExpiresAt` Attribute to TokenUpdateRequest and TokenUpdateResponse Classes

### DIFF
--- a/src/main/java/com/authlete/common/dto/TokenUpdateRequest.java
+++ b/src/main/java/com/authlete/common/dto/TokenUpdateRequest.java
@@ -157,6 +157,7 @@ public class TokenUpdateRequest implements Serializable
 
     private String accessToken;
     private long accessTokenExpiresAt;
+    private long refreshTokenExpiresAt;
     private String[] scopes;
     private Property[] properties;
     private boolean accessTokenExpiresAtUpdatedOnScopeUpdate;
@@ -228,6 +229,40 @@ public class TokenUpdateRequest implements Serializable
     public TokenUpdateRequest setAccessTokenExpiresAt(long expiresAt)
     {
         this.accessTokenExpiresAt = expiresAt;
+
+        return this;
+    }
+
+
+    /**
+     * Get the new date at which the refresh token will expire.
+     *
+     * @return
+     *         The new expiration date in milliseconds since the Unix epoch (1970-01-01).
+     */
+    public long getRefreshTokenExpiresAt()
+    {
+        return refreshTokenExpiresAt;
+    }
+
+
+    /**
+     * Set the new date at which the refresh token will expire.
+     *
+     * <p>
+     * If 0 or a negative value is given, the expiration date of the refresh token
+     * is not changed.
+     * </p>
+     *
+     * @param expiresAt
+     *         The new expiration date in milliseconds since the Unix epoch (1970-01-01).
+     *
+     * @return
+     *         {@code this} object.
+     */
+    public TokenUpdateRequest setRefreshTokenExpiresAt(long expiresAt)
+    {
+        this.refreshTokenExpiresAt = expiresAt;
 
         return this;
     }

--- a/src/main/java/com/authlete/common/dto/TokenUpdateResponse.java
+++ b/src/main/java/com/authlete/common/dto/TokenUpdateResponse.java
@@ -131,6 +131,7 @@ public class TokenUpdateResponse extends ApiResponse
     private String accessToken;
     private String tokenType;
     private long accessTokenExpiresAt;
+    private long refreshTokenExpiresAt;
     private String[] scopes;
     private Property[] properties;
     private AuthzDetails authorizationDetails;
@@ -224,6 +225,35 @@ public class TokenUpdateResponse extends ApiResponse
     public TokenUpdateResponse setAccessTokenExpiresAt(long expiresAt)
     {
         this.accessTokenExpiresAt = expiresAt;
+
+        return this;
+    }
+
+
+    /**
+     * Get the date at which the refresh token will expire.
+     *
+     * @return
+     *         The expiration date in milliseconds since the Unix epoch (1970-01-01).
+     */
+    public long getRefreshTokenExpiresAt()
+    {
+        return refreshTokenExpiresAt;
+    }
+
+
+    /**
+     * Set the date at which the refresh token will expire.
+     *
+     * @param expiresAt
+     *         The expiration date in milliseconds since the Unix epoch (1970-01-01).
+     *
+     * @return
+     *         {@code this} object.
+     */
+    public TokenUpdateResponse setRefreshTokenExpiresAt(long expiresAt)
+    {
+        this.refreshTokenExpiresAt = expiresAt;
 
         return this;
     }


### PR DESCRIPTION
This Pull Request introduces a new attribute `refreshTokenExpiresAt` to both `TokenUpdateRequest` and `TokenUpdateResponse` classes, aiming to provide a more comprehensive handling of token expiration specifics in our authentication server. Below are the key points of this enhancement:

1. **New Attribute**:
   - A new attribute `refreshTokenExpiresAt` has been added to `TokenUpdateRequest` and `TokenUpdateResponse` classes. This attribute holds the expiration time of the refresh token which is essential for managing the lifecycle of refresh tokens.

2. **Getter and Setter Methods**:
   - Accompanying getter and setter methods have been defined for the `refreshTokenExpiresAt` attribute, ensuring a clear and straightforward way to access and modify the expiration time of refresh tokens.
