### PR TITLE
Feature/refresh token expiry update

### DIFF
--- a/src/main/java/com/authlete/common/dto/TokenUpdateRequest.java
+++ b/src/main/java/com/authlete/common/dto/TokenUpdateRequest.java
@@ -161,6 +161,7 @@ public class TokenUpdateRequest implements Serializable
     private String[] scopes;
     private Property[] properties;
     private boolean accessTokenExpiresAtUpdatedOnScopeUpdate;
+    private boolean refreshTokenExpiresAtUpdatedOnScopeUpdate;
     private boolean accessTokenPersistent;
     private String accessTokenHash;
     private boolean accessTokenValueUpdated;
@@ -463,6 +464,138 @@ public class TokenUpdateRequest implements Serializable
     public TokenUpdateRequest setAccessTokenExpiresAtUpdatedOnScopeUpdate(boolean updated)
     {
         this.accessTokenExpiresAtUpdatedOnScopeUpdate = updated;
+
+        return this;
+    }
+
+
+    /**
+     * Get the flag which indicates whether {@code /auth/token/update} API attempts
+     * to update the expiration date of the refresh token when the scopes linked to
+     * the refresh token are changed by this request.
+     *
+     * @return
+     *         The flag which indicates whether {@code /auth/token/update} API
+     *         attempts to update the expiration date of the refresh token when
+     *         the scopes linked to the refresh token are changed by this request.
+     *
+     * @since 3.85
+     */
+    public boolean isRefreshTokenExpiresAtUpdatedOnScopeUpdate()
+    {
+        return refreshTokenExpiresAtUpdatedOnScopeUpdate;
+    }
+
+
+    /**
+     * Set the flag which indicates whether {@code /auth/token/update} API attempts
+     * to update the expiration date of the refresh token when the scopes linked to
+     * the refresh token are changed by this request. This request parameter is optional
+     * and its default value is {@code false}. If this request parameter is set
+     * to {@code true} and all of the following conditions are satisfied, the API
+     * performs an update on the expiration date of the refresh token even if the
+     * <code>refreshTokenExpiresAt</code> request parameter is not explicitly specified
+     * in the request.
+     *
+     * <ol>
+     * <li>The <code>refreshTokenExpiresAt</code> request parameter is not included
+     * in the request or its value is <code>0</code> (or negative).
+     * <li>The scopes linked to the refresh token are changed by the <code>scopes</code>
+     *     request parameter in the request.
+     * <li>Any of the new scopes to be linked to the refresh token has one or more
+     *     attributes specifying refresh token duration.
+     * </ol>
+     *
+     * <p>
+     * When multiple refresh token duration values are found in the attributes of
+     * the specified scopes, the smallest value among them is used.
+     * </p>
+     *
+     * <p>
+     * For more details, see the following examples.
+     * </p>
+     *
+     * <p>
+     * <b>Example 1.</b>
+     *
+     * <p>
+     * Let's say we send the following request to {@code /auth/token/update} API
+     * </p>
+     *
+     * <pre style="border: 1px solid black; padding: 0.5em; margin: 0.5em;">
+     * {
+     *   "refreshToken" : "JDGiiM9PuWT63FIwGjG9eYlGi-aZMq6CQ2IB475JUxs",
+     *   "scopes" : ["read_profile"]
+     * }</pre>
+     *
+     * <p>
+     * and <code>"read_profile"</code> has the following attributes.
+     * </p>
+     *
+     * <pre style="border: 1px solid black; padding: 0.5em; margin: 0.5em;">
+     * {
+     *   "key" : "refresh_token.duration",
+     *   "value" : "10000"
+     * }</pre>
+     *
+     * <p>
+     * In this case, the API evaluates <code>"10000"</code> as a new value of the
+     * duration of the refresh token (in seconds) and updates the expiration date
+     * of the refresh token using the duration.
+     * </p>
+     *
+     * <b>Example 2.</b>
+     *
+     * <p>
+     * Let's say we send the following request to {@code /auth/token/update} API
+     * </p>
+     *
+     * <pre style="border: 1px solid black; padding: 0.5em; margin: 0.5em;">
+     * {
+     *   "refreshToken" : "JDGiiM9PuWT63FIwGjG9eYlGi-aZMq6CQ2IB475JUxs",
+     *   "scopes" : ["read_profile", "write_profile"]
+     * }</pre>
+     *
+     * <p>
+     * and <code>"read_profile"</code> has the following attributes
+     * </p>
+     *
+     * <pre style="border: 1px solid black; padding: 0.5em; margin: 0.5em;">
+     * {
+     *   "key" : "refresh_token.duration",
+     *   "value" : "10000"
+     * }</pre>
+     *
+     * <p>
+     * and <code>"write_profile"</code> has the following attributes.
+     * </p>
+     *
+     * <pre style="border: 1px solid black; padding: 0.5em; margin: 0.5em;">
+     * {
+     *   "key" : "refresh_token.duration",
+     *   "value" : "5000"
+     * }</pre>
+     *
+     * <p>
+     * In this case, the API evaluates <code>"10000"</code> and <code>"5000"</code>
+     * as candidate values for new duration of the refresh token (in seconds) and
+     * chooses the smallest value of them (i.e. "5000" is adopted) and updates the
+     * expiration date of the refresh token using the duration.
+     * </p>
+     *
+     * @param updated
+     *         The flag which indicates whether {@code /auth/token/update} API
+     *         attempts to update the expiration date of the refresh token when
+     *         the scopes linked to the refresh token are changed by this request.
+     *
+     * @return
+     *         {@code this} object.
+     *
+     * @since 3.85
+     */
+    public TokenUpdateRequest setRefreshTokenExpiresAtUpdatedOnScopeUpdate(boolean updated)
+    {
+        this.refreshTokenExpiresAtUpdatedOnScopeUpdate = updated;
 
         return this;
     }

--- a/src/main/java/com/authlete/common/dto/TokenUpdateRequest.java
+++ b/src/main/java/com/authlete/common/dto/TokenUpdateRequest.java
@@ -157,6 +157,7 @@ public class TokenUpdateRequest implements Serializable
 
     private String accessToken;
     private long accessTokenExpiresAt;
+    private long refreshTokenExpiresAt;
     private String[] scopes;
     private Property[] properties;
     private boolean accessTokenExpiresAtUpdatedOnScopeUpdate;
@@ -228,6 +229,40 @@ public class TokenUpdateRequest implements Serializable
     public TokenUpdateRequest setAccessTokenExpiresAt(long expiresAt)
     {
         this.accessTokenExpiresAt = expiresAt;
+
+        return this;
+    }
+
+
+    /**
+     * Get the new date at which the refresh token will expire.
+     *
+     * @return
+     *         The new expiration date in milliseconds since the Unix epoch (1970-01-01).
+     */
+    public long getRefreshTokenExpiresAt()
+    {
+        return refreshTokenExpiresAt;
+    }
+
+
+    /**
+     * Set the new date at which the refresh token will expire.
+     *
+     * <p>
+     * If 0 or a negative value is given, the expiration date of the refresh token
+     * is not changed.
+     * </p>
+     *
+     * @param expiresAt
+     *         The new expiration date in milliseconds since the Unix epoch (1970-01-01).
+     *
+     * @return
+     *         {@code this} object.
+     */
+    public TokenUpdateRequest setRefreshTokenExpiresAt(long expiresAt)
+    {
+        this.refreshTokenExpiresAt = expiresAt;
 
         return this;
     }

--- a/src/main/java/com/authlete/common/dto/TokenUpdateResponse.java
+++ b/src/main/java/com/authlete/common/dto/TokenUpdateResponse.java
@@ -131,6 +131,7 @@ public class TokenUpdateResponse extends ApiResponse
     private String accessToken;
     private String tokenType;
     private long accessTokenExpiresAt;
+    private long refreshTokenExpiresAt;
     private String[] scopes;
     private Property[] properties;
     private AuthzDetails authorizationDetails;
@@ -224,6 +225,35 @@ public class TokenUpdateResponse extends ApiResponse
     public TokenUpdateResponse setAccessTokenExpiresAt(long expiresAt)
     {
         this.accessTokenExpiresAt = expiresAt;
+
+        return this;
+    }
+
+
+    /**
+     * Get the date at which the refresh token will expire.
+     *
+     * @return
+     *         The expiration date in milliseconds since the Unix epoch (1970-01-01).
+     */
+    public long getRefreshTokenExpiresAt()
+    {
+        return refreshTokenExpiresAt;
+    }
+
+
+    /**
+     * Set the date at which the refresh token will expire.
+     *
+     * @param expiresAt
+     *         The expiration date in milliseconds since the Unix epoch (1970-01-01).
+     *
+     * @return
+     *         {@code this} object.
+     */
+    public TokenUpdateResponse setRefreshTokenExpiresAt(long expiresAt)
+    {
+        this.refreshTokenExpiresAt = expiresAt;
 
         return this;
     }


### PR DESCRIPTION
## Summary
This pull request introduces new functionality to the `TokenUpdateRequest` class, enabling the update of refresh token expiration dates based on scope changes.

## Changes
- Added `isRefreshTokenExpiresAtUpdatedOnScopeUpdate()` method to check if the refresh token expiration update flag is enabled.
- Added `setRefreshTokenExpiresAtUpdatedOnScopeUpdate(boolean updated)` method to enable/disable the refresh token expiration update upon scope change.

## Implementation Details
The refresh token expiration is now conditionally updated if the following criteria are met:
1. `refreshTokenExpiresAt` parameter is not set, or its value is zero or negative.
2. The scopes associated with the token are modified during the request.
3. The new scopes include one or more attributes defining a refresh token duration.

When several duration values are present, the smallest one is chosen as the new token lifespan.

## Impact
This update aligns with version 3.85 of our API, extending the flexibility and control over refresh token expiration dates. This is particularly useful for scenarios where token lifetimes need to adapt to changing access levels or permissions.
