### PR TITLE
[feature] down-scoping

### DIFF
--- a/src/main/java/com/authlete/common/dto/AccessToken.java
+++ b/src/main/java/com/authlete/common/dto/AccessToken.java
@@ -27,7 +27,7 @@ import com.authlete.common.types.GrantType;
  */
 public class AccessToken implements Serializable
 {
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 2L;
 
 
     private String accessTokenHash;
@@ -41,6 +41,7 @@ public class AccessToken implements Serializable
     private long createdAt;
     private long lastRefreshedAt;
     private Property[] properties;
+    private String[] refreshTokenScopes;
 
 
     /**
@@ -375,6 +376,41 @@ public class AccessToken implements Serializable
     public AccessToken setProperties(Property[] properties)
     {
         this.properties = properties;
+
+        return this;
+    }
+
+
+    /**
+     * Get the scopes associated with the refresh token.
+     *
+     * @return
+     *         The scopes associated with the refresh token. May be {@code null}.
+     *
+     * @since 3.89
+     * @since Authlete API 3.0
+     */
+    public String[] getRefreshTokenScopes()
+    {
+        return refreshTokenScopes;
+    }
+
+
+    /**
+     * Set the scopes associated with the refresh token.
+     *
+     * @param refreshTokenScopes
+     *         The scopes associated with the refresh token.
+     *
+     * @return
+     *         {@code this} object.
+     *
+     * @since 3.89
+     * @since Authlete API 3.0
+     */
+    public AccessToken setRefreshTokenScopes(String[] refreshTokenScopes)
+    {
+        this.refreshTokenScopes = refreshTokenScopes;
 
         return this;
     }

--- a/src/main/java/com/authlete/common/dto/TokenCreateResponse.java
+++ b/src/main/java/com/authlete/common/dto/TokenCreateResponse.java
@@ -119,7 +119,7 @@ public class TokenCreateResponse extends ApiResponse
     }
 
 
-    private static final long serialVersionUID = 7L;
+    private static final long serialVersionUID = 8L;
     private static final String SUMMARY_FORMAT
         = "action=%s, grantType=%s, clientId=%d, subject=%s, scopes=%s, "
         + "accessToken=%s, tokenType=%s, expiresIn=%d, expiresAt=%d, refreshToken=%s";
@@ -199,6 +199,11 @@ public class TokenCreateResponse extends ApiResponse
      * @since Authlete 3.0.0
      */
     private String tokenId;
+
+    /**
+     * @since Authlete 3.0.0
+     */
+    private String[] refreshTokenScopes;
 
 
     /**
@@ -706,6 +711,42 @@ public class TokenCreateResponse extends ApiResponse
     public TokenCreateResponse setTokenId(String tokenId)
     {
         this.tokenId = tokenId;
+
+        return this;
+    }
+
+
+    /**
+     * Get the scopes associated with the refresh token.
+     *
+     * @return
+     *         The scopes associated with the refresh token. May be
+     *         {@code null}.
+     *
+     * @since 3.89
+     * @since Authlete API 3.0
+     */
+    public String[] getRefreshTokenScopes()
+    {
+        return refreshTokenScopes;
+    }
+
+
+    /**
+     * Set the scopes associated with the refresh token.
+     *
+     * @param refreshTokenScopes
+     *         The scopes associated with the refresh token.
+     *
+     * @return
+     *         {@code this} object.
+     *
+     * @since 3.89
+     * @since Authlete API 3.0
+     */
+    public TokenCreateResponse setRefreshTokenScopes(String[] refreshTokenScopes)
+    {
+        this.refreshTokenScopes = refreshTokenScopes;
 
         return this;
     }

--- a/src/main/java/com/authlete/common/dto/TokenIssueResponse.java
+++ b/src/main/java/com/authlete/common/dto/TokenIssueResponse.java
@@ -103,7 +103,7 @@ import com.authlete.common.util.Utils;
  */
 public class TokenIssueResponse extends ApiResponse
 {
-    private static final long serialVersionUID = 9L;
+    private static final long serialVersionUID = 10L;
 
 
     /**
@@ -241,6 +241,11 @@ public class TokenIssueResponse extends ApiResponse
      * @since Authlete 2.2.3
      */
     private Pair[] clientAttributes;
+
+    /**
+     * @since Authlete 3.0.0
+     */
+    private String[] refreshTokenScopes;
 
 
     /**
@@ -935,5 +940,35 @@ public class TokenIssueResponse extends ApiResponse
     public void setClientAttributes(Pair[] attributes)
     {
         this.clientAttributes = attributes;
+    }
+
+
+    /**
+     * Get the scopes associated with the refresh token.
+     *
+     * @return
+     *         The scopes associated with the refresh token. May be {@code null}.
+     *
+     * @since 3.89
+     * @since Authlete API 3.0
+     */
+    public String[] getRefreshTokenScopes()
+    {
+        return refreshTokenScopes;
+    }
+
+
+    /**
+     * Set the scopes associated with the refresh token.
+     *
+     * @param refreshTokenScopes
+     *         The scopes associated with the refresh token.
+     *
+     * @since 3.89
+     * @since Authlete API 3.0
+     */
+    public void setRefreshTokenScopes(String[] refreshTokenScopes)
+    {
+        this.refreshTokenScopes = refreshTokenScopes;
     }
 }

--- a/src/main/java/com/authlete/common/dto/TokenResponse.java
+++ b/src/main/java/com/authlete/common/dto/TokenResponse.java
@@ -872,7 +872,7 @@ import com.authlete.common.util.Utils;
  */
 public class TokenResponse extends ApiResponse
 {
-    private static final long serialVersionUID = 18L;
+    private static final long serialVersionUID = 19L;
 
 
     /**
@@ -1220,6 +1220,14 @@ public class TokenResponse extends ApiResponse
      * @since Authlete 3.0
      */
     private String dpopNonce;
+
+    /**
+     * Scopes associated with the refresh token.
+     *
+     * @since 3.89
+     * @since Authlete 3.0.0
+     */
+    private String[] refreshTokenScopes;
 
 
     /**
@@ -3015,5 +3023,36 @@ public class TokenResponse extends ApiResponse
     public void setDpopNonce(String dpopNonce)
     {
         this.dpopNonce = dpopNonce;
+    }
+
+
+    /**
+     * Get the scopes associated with the refresh token.
+     *
+     * @return
+     *         The scopes associated with the refresh token. May be
+     *         {@code null}.
+     *
+     * @since 3.89
+     * @since Authlete API 3.0
+     */
+    public String[] getRefreshTokenScopes()
+    {
+        return refreshTokenScopes;
+    }
+
+
+    /**
+     * Set the scopes associated with the refresh token.
+     *
+     * @param refreshTokenScopes
+     *         The scopes associated with the refresh token.
+     *
+     * @since 3.89
+     * @since Authlete API 3.0
+     */
+    public void setRefreshTokenScopes(String[] refreshTokenScopes)
+    {
+        this.refreshTokenScopes = refreshTokenScopes;
     }
 }


### PR DESCRIPTION
This PR adds `refreshTokenScopes` property to some API response classes for the down-scoping feature on refresh token flow. The new property `refreshTokenScopes` is named after the following statement in [RFC6749, 6. Refreshing an Access Token](https://datatracker.ietf.org/doc/html/rfc6749#section-6):

> If a new refresh token is issued, the refresh token scope MUST be identical to that of the refresh token included by the client in the request. 
