### PR TITLE
[spec] OID4VCI spec changes in December 2023

### DIFF
--- a/CHANGES.ja.md
+++ b/CHANGES.ja.md
@@ -1,6 +1,43 @@
 変更点
 ======
 
+- `CredentialIssuerMetadata` クラス
+    * `credentials_supported` から `credential_configurations_supported`
+       への名称変更に対応するため `toMap()` メソッドの実装を更新。
+
+- `CredentialOfferCreateRequest` クラス
+    * `getTxCode()` メソッドを追加。
+    * `setTxCode(String)` メソッドを追加。
+    * `getTxCodeInputMode()` メソッドを追加。
+    * `setTxCodeInputMode(String)` メソッドを追加。
+    * `getTxCodeDescription()` メソッドを追加。
+    * `setTxCodeDescription(String)` メソッドを追加。
+    * `getCredentials()` メソッドを `getCredentialConfigurations()` へ名称変更。
+    * `setCredentials(String[])` メソッドを `setCredentialConfigurations(String[])` へ名称変更。
+    * `isUserPinRequired()` メソッドを削除。
+    * `setUserPinRequired(boolean)` メソッドを削除。
+    * `getUserPinLength()` メソッドを削除。
+    * `setUserPinLength(int)` メソッドを削除。
+
+- `CredetialOfferInfo` クラス
+    * `getTxCode()` メソッドを追加。
+    * `setTxCode(String)` メソッドを追加。
+    * `getTxCodeInputMode()` メソッドを追加。
+    * `setTxCodeInputMode(String)` メソッドを追加。
+    * `getTxCodeDescription()` メソッドを追加。
+    * `setTxCodeDescription(String)` メソッドを追加。
+    * `getCredentials()` メソッドを `getCredentialConfigurations()` へ名称変更。
+    * `setCredentials(String[])` メソッドを `setCredentialConfigurations(String[])` へ名称変更。
+    * `isUserPinRequired()` メソッドを削除。
+    * `setUserPinRequired(boolean)` メソッドを削除。
+    * `getUserPin()` メソッドを削除。
+    * `setUserPin(String)` メソッドを削除。
+
+- `Service` クラス
+    * `getUserPinLength()` メソッドを廃止。
+    * `setUserPinLength(int)` メソッドを廃止。
+
+
 3.90 (2023 年 12 月 22 日)
 --------------------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,43 @@
 CHANGES
 =======
 
+- `CredentialIssuerMetadata` class
+    * Updated the implementation of the `toMap()` method to cope with the remaining
+      from `credentials_supported` to `credential_configurations_supported`.
+
+- `CredentialOfferCreateRequest` class
+    * Added `getTxCode()` method.
+    * Added `setTxCode(String)` method.
+    * Added `getTxCodeInputMode()` method.
+    * Added `setTxCodeInputMode(String)` method.
+    * Added `getTxCodeDescription()` method.
+    * Added `setTxCodeDescription(String)` method.
+    * Renamed `getCredentials()` method to `getCredentialConfigurations()`.
+    * Renamed `setCredentials(String[])` method to `setCredentialConfigurations(String[])`.
+    * Removed `isUserPinRequired()` method.
+    * Removed `setUserPinRequired(boolean)` method.
+    * Removed `getUserPinLength()` method.
+    * Removed `setUserPinLength(int)` method.
+
+- `CredetialOfferInfo` class
+    * Added `getTxCode()` method.
+    * Added `setTxCode(String)` method.
+    * Added `getTxCodeInputMode()` method.
+    * Added `setTxCodeInputMode(String)` method.
+    * Added `getTxCodeDescription()` method.
+    * Added `setTxCodeDescription(String)` method.
+    * Renamed `getCredentials()` method to `getCredentialConfigurations()`.
+    * Renamed `setCredentials(String[])` method to `setCredentialConfigurations(String[])`.
+    * Removed `isUserPinRequired()` method.
+    * Removed `setUserPinRequired(boolean)` method.
+    * Removed `getUserPin()` method.
+    * Removed `setUserPin(String)` method.
+
+- `Service` class
+    * Deprecated `getUserPinLength()` method.
+    * Deprecated `setUserPinLength(int)` method.
+
+
 3.90 (2023-12-22)
 -----------------
 

--- a/src/main/java/com/authlete/common/dto/CredentialIssuerMetadata.java
+++ b/src/main/java/com/authlete/common/dto/CredentialIssuerMetadata.java
@@ -38,7 +38,7 @@ import static com.authlete.common.util.MapUtils.*;
  * <li>{@code credential_response_encryption_alg_values_supported}
  * <li>{@code credential_response_encryption_enc_values_supported}
  * <li>{@code require_credential_response_encryption}
- * <li>{@code credentials_supported}
+ * <li>{@code credential_configurations_supported}
  * </ul>
  *
  * <p>
@@ -62,6 +62,9 @@ import static com.authlete.common.util.MapUtils.*;
  * The "{@code authorization_server}" metadata has been renamed to
  * "{@code authorization_servers}", and its type has been changed from a string
  * to a JSON array.
+ * <li>
+ * The "{@code credentials_supported}" metadata has been renamed to
+ * "{@code credential_configurations_supported}". (December, 2023)
  * </ol>
  *
  * @since 3.55
@@ -137,7 +140,7 @@ public class CredentialIssuerMetadata implements Serializable
 
 
     /**
-     * A JSON object describing supported credentials.
+     * A JSON object describing supported credential configurations.
      */
     private String credentialsSupported;
 
@@ -477,8 +480,7 @@ public class CredentialIssuerMetadata implements Serializable
      *
      * <p>
      * If this flag is {@code true}, every credential request to the credential
-     * issuer must include encryption-related parameters such as
-     * {@code credential_response_encryption_alg}.
+     * issuer must include the {@code credential_response_encryption} property.
      * </p>
      *
      * @return
@@ -499,8 +501,7 @@ public class CredentialIssuerMetadata implements Serializable
      *
      * <p>
      * If this flag is {@code true}, every credential request to the credential
-     * issuer must include encryption-related parameters such as
-     * {@code credential_response_encryption_alg}.
+     * issuer must include the {@code credential_response_encryption} property.
      * </p>
      *
      * @param required
@@ -520,8 +521,9 @@ public class CredentialIssuerMetadata implements Serializable
 
 
     /**
-     * Get the information about supported credentials in the JSON format.
-     * This property corresponds to the {@code credentials_supported} metadata.
+     * Get the information about supported credential configurations in the
+     * JSON format. This property corresponds to the
+     * {@code credential_configurations_supported} metadata.
      *
      * <p>
      * To make the feature of credential issuance function, this property must
@@ -535,9 +537,15 @@ public class CredentialIssuerMetadata implements Serializable
      * array to a JSON object.
      * </p>
      *
+     * <p>
+     * NOTE: Due to another breaking change made in December 2023, the
+     * {@code credentials_supported} metadata has been renamed to
+     * {@code credential_configurations_supported}.
+     * </p>
+     *
      * @return
-     *         The supported credentials. If not null, the value is a string
-     *         representing a JSON object.
+     *         The supported credential configurations. If not null, the value
+     *         is a string representing a JSON object.
      */
     public String getCredentialsSupported()
     {
@@ -546,8 +554,9 @@ public class CredentialIssuerMetadata implements Serializable
 
 
     /**
-     * Set the information about supported credentials in the JSON format.
-     * This property corresponds to the {@code credentials_supported} metadata.
+     * Set the information about supported credential configurations in the
+     * JSON format. This property corresponds to the
+     * {@code credential_configurations_supported} metadata.
      *
      * <p>
      * To make the feature of credential issuance function, this property must
@@ -561,9 +570,15 @@ public class CredentialIssuerMetadata implements Serializable
      * array to a JSON object.
      * </p>
      *
+     * <p>
+     * NOTE: Due to another breaking change made in December 2023, the
+     * {@code credentials_supported} metadata has been renamed to
+     * {@code credential_configurations_supported}.
+     * </p>
+     *
      * @param credentialsSupported
-     *         The supported credentials. If not null, the value must be a
-     *         string representing a JSON object.
+     *         The supported credential configurations. If not null, the value
+     *         is a string representing a JSON object.
      *
      * @return
      *         {@code this} object.
@@ -618,7 +633,7 @@ public class CredentialIssuerMetadata implements Serializable
      *     "https://credential-issuer.example.com/batch_credential",
      *   "deferred_credential_endpoint":
      *     "https://credential-issuer.example.com/deferred_credential",
-     *   "credentials_supported": {
+     *   "credential_configurations_supported": {
      *     "UniversityDegreeCredential": {
      *       "format": "jwt_vc_json",
      *       "scope": "UniversityDegree",
@@ -653,6 +668,12 @@ public class CredentialIssuerMetadata implements Serializable
      * a JSON array to a JSON object.
      * </p>
      *
+     * <p>
+     * NOTE: Due to another breaking change made in December 2023, the
+     * {@code credentials_supported} metadata has been renamed to
+     * {@code credential_configurations_supported}.
+     * </p>
+     *
      * @return
      *         A {@code Map} instance that represents a JSON object conforming
      *         to the format of the credential issuer metadata.
@@ -677,7 +698,7 @@ public class CredentialIssuerMetadata implements Serializable
         try
         {
             // Parse the value of 'credentialsSupported' as a JSON object.
-            putJsonObject(map, "credentials_supported", credentialsSupported, false);
+            putJsonObject(map, "credential_configurations_supported", credentialsSupported, false);
         }
         catch (Exception cause)
         {

--- a/src/main/java/com/authlete/common/dto/CredentialJwtIssuerMetadataRequest.java
+++ b/src/main/java/com/authlete/common/dto/CredentialJwtIssuerMetadataRequest.java
@@ -24,8 +24,8 @@ import java.io.Serializable;
  *
  * <p>
  * The Authlete API is supposed to be called from within the implementation of
- * the JWT issuer metadata endpoint ({@code /.well-known/jwt-issuer}) of the
- * credential issuer.
+ * the JWT VC issuer metadata endpoint ({@code /.well-known/jwt-vc-issuer}) of
+ * the credential issuer.
  * </p>
  *
  * <p>
@@ -45,9 +45,15 @@ import java.io.Serializable;
  * </blockquote>
  *
  * <p>
- * Note that the JWT issuer metadata endpoint ({@code /.well-known/jwt-issuer})
+ * Note that the JWT VC issuer metadata endpoint ({@code /.well-known/jwt-vc-issuer})
  * is different from the credential issuer metadata endpoint
  * ({@code /.well-known/openid-credential-issuer}).
+ * </p>
+ *
+ * <p>
+ * NOTE: The well-known path has been changed from {@code /.well-known/jwt-issuer}
+ * to {@code /.well-known/jwt-vc-issuer} by a breaking change of the SD-JWT VC
+ * specification.
  * </p>
  *
  * @since 3.79

--- a/src/main/java/com/authlete/common/dto/CredentialJwtIssuerMetadataResponse.java
+++ b/src/main/java/com/authlete/common/dto/CredentialJwtIssuerMetadataResponse.java
@@ -21,8 +21,8 @@ package com.authlete.common.dto;
  *
  * <p>
  * The Authlete API is supposed to be called from within the implementation of
- * the JWT issuer metadata endpoint ({@code /.well-known/jwt-issuer}) of the
- * credential issuer.
+ * the JWT VC issuer metadata endpoint ({@code /.well-known/jwt-vc-issuer}) of
+ * the credential issuer.
  * </p>
  *
  * <p>
@@ -42,7 +42,7 @@ package com.authlete.common.dto;
  *
  * </p>
  * In this case, the implementation of the JWT issuer metadata endpoint
- * ({@code /.well-known/jwt-issuer}) of the credential issuer should return
+ * ({@code /.well-known/jwt-vc-issuer}) of the credential issuer should return
  * an HTTP response with the HTTP status code "{@code 200 OK}" and the content
  * type "{@code application/json}". The message body of the response has been
  * prepared by Authlete's {@code /vci/jwtissuer} API and it is available as
@@ -131,6 +131,12 @@ package com.authlete.common.dto;
  * what they actually return in the case of internal server error.
  * </p>
  *
+ * <p>
+ * NOTE: The well-known path has been changed from {@code /.well-known/jwt-issuer}
+ * to {@code /.well-known/jwt-vc-issuer} by a breaking change of the SD-JWT VC
+ * specification.
+ * </p>
+ *
  * @since 3.79
  * @since Authlete 3.0
  *
@@ -145,7 +151,7 @@ public class CredentialJwtIssuerMetadataResponse extends ApiResponse
 
     /**
      * The next action that the implementation of the JWT issuer metadata
-     * endpoint ({@code /.well-known/jwt-issuer}) should take after getting
+     * endpoint ({@code /.well-known/jwt-vc-issuer}) should take after getting
      * a response from Authlete's {@code /vci/jwtissuer} API.
      *
      * @since 3.79

--- a/src/main/java/com/authlete/common/dto/CredentialOfferCreateRequest.java
+++ b/src/main/java/com/authlete/common/dto/CredentialOfferCreateRequest.java
@@ -43,14 +43,18 @@ import java.io.Serializable;
  * <pre>
  * {
  *   "credential_issuer": "...",
- *   "credentials": [ ... ],
+ *   "credential_configurations": [ ... ],
  *   "grants": {
  *     "authorization_code": {
  *       "issuer_state": "..."
  *     },
  *     "urn:ietf:params:oauth:grant-type:pre-authorized_code": {
  *       "pre-authorized_code": "...",
- *       "user_pin_required": true
+ *       "tx_code": {
+ *         "input_mode": "numeric",
+ *         "length": 6,
+ *         "description": "..."
+ *       }
  *     }
  *   }
  * }
@@ -76,6 +80,13 @@ import java.io.Serializable;
  * string to an array of strings.
  * </p>
  *
+ * <p>
+ * Due to another breaking change made in December 2023, the {@code credentials}
+ * property in a credential offer has been renamed to
+ * {@code credential_configurations}. In addition, the {@code user_pin_required}
+ * boolean property has been replaced with the {@code tx_code} JSON object.
+ * </p>
+ *
  * @since 3.59
  * @since Authlete 3.0
  *
@@ -84,13 +95,15 @@ import java.io.Serializable;
  */
 public class CredentialOfferCreateRequest implements Serializable
 {
-    private static final long serialVersionUID = 3L;
+    private static final long serialVersionUID = 4L;
 
 
     /**
-     * The value of the {@code credentials} array.
+     * The value of the {@code credential_configurations} array.
+     *
+     * @since 3.91
      */
-    private String[] credentials;
+    private String[] credentialConfigurations;
 
 
     /**
@@ -113,19 +126,6 @@ public class CredentialOfferCreateRequest implements Serializable
      * in the {@code grants} object.
      */
     private boolean preAuthorizedCodeGrantIncluded;
-
-
-    /**
-     * The flag to include the {@code user_pin_required} property with the
-     * value {@code true}.
-     */
-    private boolean userPinRequired;
-
-
-    /**
-     * The length of the user PIN to generate.
-     */
-    private int userPinLength;
 
 
     /**
@@ -182,13 +182,37 @@ public class CredentialOfferCreateRequest implements Serializable
 
 
     /**
-     * Get the value of the {@code credentials} array.
+     * The transaction code.
+     *
+     * @since 3.91
+     */
+    private String txCode;
+
+
+    /**
+     * The input mode of the transaction code.
+     *
+     * @since 3.91
+     */
+    private String txCodeInputMode;
+
+
+    /**
+     * The description of the transaction code.
+     *
+     * @since 3.91
+     */
+    private String txCodeDescription;
+
+
+    /**
+     * Get the value of the {@code credential_configurations} array.
      *
      * <blockquote>
      * <pre>
      * {
      *   "credential_issuer": "...",
-     *   <span style="color:darkred;">"credentials": [ ... ]</span>,
+     *   <span style="color:darkred;">"credential_configurations": [ ... ]</span>,
      *   "grants": { ... }
      * }
      * </pre>
@@ -204,23 +228,31 @@ public class CredentialOfferCreateRequest implements Serializable
      * with the breaking change of the OID4VCI specification.
      * </p>
      *
+     * <p>
+     * NOTE: Due to the breaking change made in December 2023, the
+     * {@code credentials} property in a credential offer has been renamed to
+     * {@code credential_configurations}.
+     * </p>
+     *
      * @return
-     *         The value of the {@code credentials} array.
+     *         The value of the {@code credential_configurations} array.
+     *
+     * @since 3.91
      */
-    public String[] getCredentials()
+    public String[] getCredentialConfigurations()
     {
-        return credentials;
+        return credentialConfigurations;
     }
 
 
     /**
-     * Set the value of the {@code credentials} array.
+     * Set the value of the {@code credential_configurations} array.
      *
      * <blockquote>
      * <pre>
      * {
      *   "credential_issuer": "...",
-     *   <span style="color:darkred;">"credentials": [ ... ]</span>,
+     *   <span style="color:darkred;">"credential_configurations": [ ... ]</span>,
      *   "grants": { ... }
      * }
      * </pre>
@@ -230,17 +262,23 @@ public class CredentialOfferCreateRequest implements Serializable
      * This property is mandatory.
      * </p>
      *
-     * @param credentials
-     *         The value of the {@code credentials} array.
+     * <p>
+     * NOTE: Due to the breaking change made in December 2023, the
+     * {@code credentials} property in a credential offer has been renamed to
+     * {@code credential_configurations}.
+     * </p>
+     *
+     * @param configurations
+     *         The value of the {@code credential_configurations} array.
      *
      * @return
      *         {@code this} object.
      *
-     * @since 3.86
+     * @since 3.91
      */
-    public CredentialOfferCreateRequest setCredentials(String[] credentials)
+    public CredentialOfferCreateRequest setCredentialConfigurations(String[] configurations)
     {
-        this.credentials = credentials;
+        this.credentialConfigurations = configurations;
 
         return this;
     }
@@ -254,7 +292,7 @@ public class CredentialOfferCreateRequest implements Serializable
      * <pre>
      * {
      *   "credential_issuer": "...",
-     *   "credentials": [ ... ],
+     *   "credential_configurations": [ ... ],
      *   "grants": {
      *     <span style="color:darkred;">"authorization_code"</span>: { ... }
      *   }
@@ -280,7 +318,7 @@ public class CredentialOfferCreateRequest implements Serializable
      * <pre>
      * {
      *   "credential_issuer": "...",
-     *   "credentials": [ ... ],
+     *   "credential_configurations": [ ... ],
      *   "grants": {
      *     <span style="color:darkred;">"authorization_code"</span>: { ... }
      *   }
@@ -310,7 +348,7 @@ public class CredentialOfferCreateRequest implements Serializable
      * <pre>
      * {
      *   "credential_issuer": "...",
-     *   "credentials": [ ... ],
+     *   "credential_configurations": [ ... ],
      *   "grants": {
      *     "authorization_code": {
      *       <span style="color:darkred;">"issuer_state"</span>: "..."
@@ -344,7 +382,7 @@ public class CredentialOfferCreateRequest implements Serializable
      * <pre>
      * {
      *   "credential_issuer": "...",
-     *   "credentials": [ ... ],
+     *   "credential_configurations": [ ... ],
      *   "grants": {
      *     "authorization_code": {
      *       <span style="color:darkred;">"issuer_state"</span>: "..."
@@ -383,7 +421,7 @@ public class CredentialOfferCreateRequest implements Serializable
      * <pre>
      * {
      *   "credential_issuer": "...",
-     *   "credentials": [ ... ],
+     *   "credential_configurations": [ ... ],
      *   "grants": {
      *     <span style="color:darkred;">"urn:ietf:params:oauth:grant-type:pre-authorized_code"</span>: { ... }
      *   }
@@ -423,7 +461,7 @@ public class CredentialOfferCreateRequest implements Serializable
      * <pre>
      * {
      *   "credential_issuer": "...",
-     *   "credentials": [ ... ],
+     *   "credential_configurations": [ ... ],
      *   "grants": {
      *     <span style="color:darkred;">"urn:ietf:params:oauth:grant-type:pre-authorized_code"</span>: { ... }
      *   }
@@ -454,119 +492,6 @@ public class CredentialOfferCreateRequest implements Serializable
     public CredentialOfferCreateRequest setPreAuthorizedCodeGrantIncluded(boolean included)
     {
         this.preAuthorizedCodeGrantIncluded = included;
-
-        return this;
-    }
-
-
-    /**
-     * Get the flag to include the {@code user_pin_required} property with the
-     * value {@code true}.
-     *
-     * <blockquote>
-     * <pre>
-     * {
-     *   "credential_issuer": "...",
-     *   "credentials": [ ... ],
-     *   "grants": {
-     *     "urn:ietf:params:oauth:grant-type:pre-authorized_code": {
-     *       "pre-authorized_code": "...",
-     *       <span style="color:darkred;">"user_pin_required": true</span>
-     *     }
-     *   }
-     * }
-     * </pre>
-     * </blockquote>
-     *
-     * @return
-     *         {@code true} if the {@code user_pin_required} property will be
-     *         included with the value {@code true}.
-     *         {@code false} if the property will be omitted.
-     */
-    public boolean isUserPinRequired()
-    {
-        return userPinRequired;
-    }
-
-
-    /**
-     * Set the flag to include the {@code user_pin_required} property with the
-     * value {@code true}.
-     *
-     * <blockquote>
-     * <pre>
-     * {
-     *   "credential_issuer": "...",
-     *   "credentials": [ ... ],
-     *   "grants": {
-     *     "urn:ietf:params:oauth:grant-type:pre-authorized_code": {
-     *       "pre-authorized_code": "...",
-     *       <span style="color:darkred;">"user_pin_required": true</span>
-     *     }
-     *   }
-     * }
-     * </pre>
-     * </blockquote>
-     *
-     * @param included
-     *         {@code true} to include the {@code user_pin_required} property
-     *         with the value {@code true}. {@code false} to omit the property.
-     *
-     * @return
-     *         {@code this} object.
-     */
-    public CredentialOfferCreateRequest setUserPinRequired(boolean included)
-    {
-        this.userPinRequired = included;
-
-        return this;
-    }
-
-
-    /**
-     * Get the length of the user PIN associated with the credential offer.
-     *
-     * <p>
-     * Authlete generates a user PIN of the specified length when necessary.
-     * The maximum length that can be specified is 8 as the specification
-     * requires so. When this property is omitted or its value is 0 or
-     * negative, the value of the {@code userPinLength} property of the
-     * service is used.
-     * </p>
-     *
-     * @return
-     *         The length of the user PIN.
-     *
-     * @see Service#getUserPinLength()
-     */
-    public int getUserPinLength()
-    {
-        return userPinLength;
-    }
-
-
-    /**
-     * Set the length of the user PIN associated with the credential offer.
-     *
-     * <p>
-     * Authlete generates a user PIN of the specified length when necessary.
-     * The maximum length that can be specified is 8 as the specification
-     * requires so. When this property is omitted or its value is 0 or
-     * negative, the value of the {@code userPinLength} property of the
-     * service is used.
-     * </p>
-     *
-     * @param length
-     *         The length of the user PIN.
-     *
-     * @return
-     *         {@code this} object.
-     *
-     * @see Service#setUserPinLength(int)
-     */
-    public CredentialOfferCreateRequest setUserPinLength(int length)
-    {
-        this.userPinLength = length;
 
         return this;
     }
@@ -872,6 +797,265 @@ public class CredentialOfferCreateRequest implements Serializable
     public CredentialOfferCreateRequest setAcr(String acr)
     {
         this.acr = acr;
+
+        return this;
+    }
+
+
+    /**
+     * Get the transaction code that should be associated with the credential
+     * offer.
+     *
+     * <p>
+     * If this parameter is not empty and the
+     * {@code preAuthorizedCodeGrantIncluded} parameter is true, the
+     * {@code urn:ietf:params:oauth:grant-type:pre-authorized_code} object
+     * will include the {@code tx_code} object.
+     * </p>
+     *
+     * <p>
+     * The length of the value of this parameter will be used as the value of
+     * the {@code length} property in the {@code tx_code} object.
+     * </p>
+     *
+     * <blockquote>
+     * <pre>
+     * {
+     *   "credential_issuer": "...",
+     *   "credential_configurations": [ ... ],
+     *   "grants": {
+     *     "urn:ietf:params:oauth:grant-type:pre-authorized_code": {
+     *       "pre-authorized_code": "...",
+     *       <span style="color:darkred;">"tx_code"</span>: {
+     *         "length": length
+     *       }
+     *     }
+     *   }
+     * }
+     * </pre>
+     * </blockquote>
+     *
+     * @return
+     *         The transaction code.
+     *
+     * @since 3.91
+     */
+    public String getTxCode()
+    {
+        return txCode;
+    }
+
+
+    /**
+     * Set the transaction code that should be associated with the credential
+     * offer.
+     *
+     * <p>
+     * If this parameter is not empty and the
+     * {@code preAuthorizedCodeGrantIncluded} parameter is true, the
+     * {@code urn:ietf:params:oauth:grant-type:pre-authorized_code} object
+     * will include the {@code tx_code} object.
+     * </p>
+     *
+     * <p>
+     * The length of the value of this parameter will be used as the value of
+     * the {@code length} property in the {@code tx_code} object.
+     * </p>
+     *
+     * <blockquote>
+     * <pre>
+     * {
+     *   "credential_issuer": "...",
+     *   "credential_configurations": [ ... ],
+     *   "grants": {
+     *     "urn:ietf:params:oauth:grant-type:pre-authorized_code": {
+     *       "pre-authorized_code": "...",
+     *       <span style="color:darkred;">"tx_code"</span>: {
+     *         "length": length
+     *       }
+     *     }
+     *   }
+     * }
+     * </pre>
+     * </blockquote>
+     *
+     * @param txCode
+     *         The transaction code.
+     *
+     * @return
+     *         {@code this} object.
+     *
+     * @since 3.91
+     */
+    public CredentialOfferCreateRequest setTxCode(String txCode)
+    {
+        this.txCode = txCode;
+
+        return this;
+    }
+
+
+    /**
+     * Get the input mode of the transaction code.
+     *
+     * <p>
+     * The value of this property will be used as the value of the
+     * {@code input_mode} property in the {@code tx_code} object.
+     * </p>
+     *
+     * <blockquote>
+     * <pre>
+     * {
+     *   "credential_issuer": "...",
+     *   "credential_configurations": [ ... ],
+     *   "grants": {
+     *     "urn:ietf:params:oauth:grant-type:pre-authorized_code": {
+     *       "pre-authorized_code": "...",
+     *       "tx_code": {
+     *         "length": length,
+     *         <span style="color:darkred;">"input_mode": "..."</span>
+     *       }
+     *     }
+     *   }
+     * }
+     * </pre>
+     * </blockquote>
+     *
+     * @return
+     *         The input mode of the transaction code.
+     *
+     * @since 3.91
+     */
+    public String getTxCodeInputMode()
+    {
+        return txCodeInputMode;
+    }
+
+
+    /**
+     * Set the input mode of the transaction code.
+     *
+     * <p>
+     * The value of this property will be used as the value of the
+     * {@code input_mode} property in the {@code tx_code} object.
+     * </p>
+     *
+     * <blockquote>
+     * <pre>
+     * {
+     *   "credential_issuer": "...",
+     *   "credential_configurations": [ ... ],
+     *   "grants": {
+     *     "urn:ietf:params:oauth:grant-type:pre-authorized_code": {
+     *       "pre-authorized_code": "...",
+     *       "tx_code": {
+     *         "length": length,
+     *         <span style="color:darkred;">"input_mode": "..."</span>
+     *       }
+     *     }
+     *   }
+     * }
+     * </pre>
+     * </blockquote>
+     *
+     * <p>
+     * Possible values listed in the current draft of the OID4VCI specification
+     * are "{@code numeric}" and "{@code text}" only, but the
+     * {@code /vci/offer/create} API accepts other values for the future
+     * extension in addition to the predefined ones.
+     * </p>
+     *
+     * @param inputMode
+     *         The input mode of the transaction code.
+     *
+     * @return
+     *         {@code this} object.
+     *
+     * @since 3.91
+     */
+    public CredentialOfferCreateRequest setTxCodeInputMode(String inputMode)
+    {
+        this.txCodeInputMode = inputMode;
+
+        return this;
+    }
+
+
+    /**
+     * Get the description of the transaction code.
+     *
+     * <p>
+     * The value of this property will be used as the value of the
+     * {@code description} property in the {@code tx_code} object.
+     * </p>
+     *
+     * <blockquote>
+     * <pre>
+     * {
+     *   "credential_issuer": "...",
+     *   "credential_configurations": [ ... ],
+     *   "grants": {
+     *     "urn:ietf:params:oauth:grant-type:pre-authorized_code": {
+     *       "pre-authorized_code": "...",
+     *       "tx_code": {
+     *         "length": length,
+     *         <span style="color:darkred;">"description": "..."</span>
+     *       }
+     *     }
+     *   }
+     * }
+     * </pre>
+     * </blockquote>
+     *
+     * @return
+     *         The description of the transaction code.
+     *
+     * @since 3.91
+     */
+    public String getTxCodeDescription()
+    {
+        return txCodeDescription;
+    }
+
+
+    /**
+     * Set the description of the transaction code.
+     *
+     * <p>
+     * The value of this property will be used as the value of the
+     * {@code description} property in the {@code tx_code} object.
+     * </p>
+     *
+     * <blockquote>
+     * <pre>
+     * {
+     *   "credential_issuer": "...",
+     *   "credential_configurations": [ ... ],
+     *   "grants": {
+     *     "urn:ietf:params:oauth:grant-type:pre-authorized_code": {
+     *       "pre-authorized_code": "...",
+     *       "tx_code": {
+     *         "length": length,
+     *         <span style="color:darkred;">"description": "..."</span>
+     *       }
+     *     }
+     *   }
+     * }
+     * </pre>
+     * </blockquote>
+     *
+     * @param description
+     *         The description of the transaction code. The length of the
+     *         description must not exceed 300.
+     *
+     * @return
+     *         {@code this} object.
+     *
+     * @since 3.91
+     */
+    public CredentialOfferCreateRequest setTxCodeDescription(String description)
+    {
+        this.txCodeDescription = description;
 
         return this;
     }

--- a/src/main/java/com/authlete/common/dto/CredentialOfferInfo.java
+++ b/src/main/java/com/authlete/common/dto/CredentialOfferInfo.java
@@ -42,6 +42,13 @@ import java.net.URI;
  * string to an array of strings.
  * </p>
  *
+ * <p>
+ * Due to another breaking change made in December 2023, the {@code credentials}
+ * property in a credential offer has been renamed to
+ * {@code credential_configurations}. In addition, the {@code user_pin_required}
+ * boolean property has been replaced with the {@code tx_code} JSON object.
+ * </p>
+ *
  * @since 3.59
  * @since Authlete 3.0
  *
@@ -50,7 +57,7 @@ import java.net.URI;
  */
 public class CredentialOfferInfo implements Serializable
 {
-    private static final long serialVersionUID = 3L;
+    private static final long serialVersionUID = 4L;
 
 
     /**
@@ -74,9 +81,11 @@ public class CredentialOfferInfo implements Serializable
 
 
     /**
-     * The value of the {@code credentials} array.
+     * The value of the {@code credential_configurations} array.
+     *
+     * @since 3.91
      */
-    private String[] credentials;
+    private String[] credentialConfigurations;
 
 
     /**
@@ -115,20 +124,6 @@ public class CredentialOfferInfo implements Serializable
      * the {@code grants} object.
      */
     private String preAuthorizedCode;
-
-
-    /**
-     * The value of the {@code user_pin_required} property in the
-     * {@code urn:ietf:params:oauth:grant-type:pre-authorized_code} object in
-     * the {@code grants} object.
-     */
-    private boolean userPinRequired;
-
-
-    /**
-     * The value of the user PIN associated with the credential offer.
-     */
-    private String userPin;
 
 
     /**
@@ -182,6 +177,30 @@ public class CredentialOfferInfo implements Serializable
      * @since 3.62
      */
     private String acr;
+
+
+    /**
+     * The transaction code.
+     *
+     * @since 3.91
+     */
+    private String txCode;
+
+
+    /**
+     * The input mode of the transaction code.
+     *
+     * @since 3.91
+     */
+    private String txCodeInputMode;
+
+
+    /**
+     * The description of the transaction code.
+     *
+     * @since 3.91
+     */
+    private String txCodeDescription;
 
 
     /**
@@ -241,14 +260,18 @@ public class CredentialOfferInfo implements Serializable
      * <pre>
      * {
      *   "credential_issuer": "...",
-     *   "credentials": [ ... ],
+     *   "credential_configurations": [ ... ],
      *   "grants": {
      *     "authorization_code": {
      *       "issuer_state": "..."
      *     },
      *     "urn:ietf:params:oauth:grant-type:pre-authorized_code": {
      *       "pre-authorized_code": "...",
-     *       "user_pin_required": true
+     *       "tx_code": {
+     *         "input_mode": "numeric",
+     *         "length": 6,
+     *         "description": "..."
+     *       }
      *     }
      *   }
      * }
@@ -282,14 +305,18 @@ public class CredentialOfferInfo implements Serializable
      * <pre>
      * {
      *   "credential_issuer": "...",
-     *   "credentials": [ ... ],
+     *   "credential_configurations": [ ... ],
      *   "grants": {
      *     "authorization_code": {
      *       "issuer_state": "..."
      *     },
      *     "urn:ietf:params:oauth:grant-type:pre-authorized_code": {
      *       "pre-authorized_code": "...",
-     *       "user_pin_required": true
+     *       "tx_code": {
+     *         "input_mode": "numeric",
+     *         "length": 6,
+     *         "description": "..."
+     *       }
      *     }
      *   }
      * }
@@ -317,7 +344,7 @@ public class CredentialOfferInfo implements Serializable
      * <pre>
      * {
      *   <span style="color:darkred;">"credential_issuer": "..."</span>,
-     *   "credentials": [ ... ],
+     *   "credential_configurations": [ ... ],
      *   "grants": { ... }
      * }
      * </pre>
@@ -341,7 +368,7 @@ public class CredentialOfferInfo implements Serializable
      * <pre>
      * {
      *   <span style="color:darkred;">"credential_issuer": "..."</span>,
-     *   "credentials": [ ... ],
+     *   "credential_configurations": [ ... ],
      *   "grants": { ... }
      * }
      * </pre>
@@ -364,14 +391,14 @@ public class CredentialOfferInfo implements Serializable
 
 
     /**
-     * Get the value of the {@code credentials} property of the credential
-     * offer.
+     * Get the value of the {@code credential_configurations} property of
+     * the credential offer.
      *
      * <blockquote>
      * <pre>
      * {
      *   "credential_issuer": "...",
-     *   <span style="color:darkred;">"credentials": [ ... ]</span>,
+     *   <span style="color:darkred;">"credential_configurations": [ ... ]</span>,
      *   "grants": { ... }
      * }
      * </pre>
@@ -383,42 +410,56 @@ public class CredentialOfferInfo implements Serializable
      * with the breaking change of the OID4VCI specification.
      * </p>
      *
+     * <p>
+     * NOTE: Due to the breaking change made in December 2023, the
+     * {@code credentials} property in a credential offer has been renamed to
+     * {@code credential_configurations}.
+     * </p>
+     *
      * @return
-     *         The value of the {@code credentials} property of the credential
-     *         offer.
+     *         The value of the {@code credential_configurations} property of
+     *         the credential offer.
+     *
+     * @since 3.91
      */
-    public String[] getCredentials()
+    public String[] getCredentialConfigurations()
     {
-        return credentials;
+        return credentialConfigurations;
     }
 
 
     /**
-     * Set the value of the {@code credentials} property of the credential
-     * offer.
+     * Set the value of the {@code credential_configurations} property of
+     * the credential offer.
      *
      * <blockquote>
      * <pre>
      * {
      *   "credential_issuer": "...",
-     *   <span style="color:darkred;">"credentials": [ ... ]</span>,
+     *   <span style="color:darkred;">"credential_configurations": [ ... ]</span>,
      *   "grants": { ... }
      * }
      * </pre>
      * </blockquote>
      *
-     * @param credentials
-     *         The value of the {@code credentials} property of the credential
-     *         offer.
+     * <p>
+     * NOTE: Due to the breaking change made in December 2023, the
+     * {@code credentials} property in a credential offer has been renamed to
+     * {@code credential_configurations}.
+     * </p>
+     *
+     * @param configurations
+     *         The value of the {@code credential_configurations} property of
+     *         the credential offer.
      *
      * @return
      *         {@code this} object.
      *
-     * @since 3.86
+     * @since 3.91
      */
-    public CredentialOfferInfo setCredentials(String[] credentials)
+    public CredentialOfferInfo setCredentialConfigurations(String[] configurations)
     {
-        this.credentials = credentials;
+        this.credentialConfigurations = configurations;
 
         return this;
     }
@@ -432,7 +473,7 @@ public class CredentialOfferInfo implements Serializable
      * <pre>
      * {
      *   "credential_issuer": "...",
-     *   "credentials": [ ... ],
+     *   "credential_configurations": [ ... ],
      *   "grants": {
      *     <span style="color:darkred;">"authorization_code"</span>: { ... }
      *   }
@@ -458,7 +499,7 @@ public class CredentialOfferInfo implements Serializable
      * <pre>
      * {
      *   "credential_issuer": "...",
-     *   "credentials": [ ... ],
+     *   "credential_configurations": [ ... ],
      *   "grants": {
      *     <span style="color:darkred;">"authorization_code"</span>: { ... }
      *   }
@@ -490,7 +531,7 @@ public class CredentialOfferInfo implements Serializable
      * <pre>
      * {
      *   "credential_issuer": "...",
-     *   "credentials": [ ... ],
+     *   "credential_configurations": [ ... ],
      *   "grants": {
      *     "authorization_code": {
      *       <span style="color:darkred;">"issuer_state"</span>: "..."
@@ -520,7 +561,7 @@ public class CredentialOfferInfo implements Serializable
      * <pre>
      * {
      *   "credential_issuer": "...",
-     *   "credentials": [ ... ],
+     *   "credential_configurations": [ ... ],
      *   "grants": {
      *     "authorization_code": {
      *       <span style="color:darkred;">"issuer_state"</span>: "..."
@@ -554,7 +595,7 @@ public class CredentialOfferInfo implements Serializable
      * <pre>
      * {
      *   "credential_issuer": "...",
-     *   "credentials": [ ... ],
+     *   "credential_configurations": [ ... ],
      *   "grants": {
      *     "authorization_code": {
      *       <span style="color:darkred;">"issuer_state": "..."</span>
@@ -583,7 +624,7 @@ public class CredentialOfferInfo implements Serializable
      * <pre>
      * {
      *   "credential_issuer": "...",
-     *   "credentials": [ ... ],
+     *   "credential_configurations": [ ... ],
      *   "grants": {
      *     "authorization_code": {
      *       <span style="color:darkred;">"issuer_state": "..."</span>
@@ -618,7 +659,7 @@ public class CredentialOfferInfo implements Serializable
      * <pre>
      * {
      *   "credential_issuer": "...",
-     *   "credentials": [ ... ],
+     *   "credential_configurations": [ ... ],
      *   "grants": {
      *     <span style="color:darkred;">"urn:ietf:params:oauth:grant-type:pre-authorized_code"</span>: { ... }
      *   }
@@ -646,7 +687,7 @@ public class CredentialOfferInfo implements Serializable
      * <pre>
      * {
      *   "credential_issuer": "...",
-     *   "credentials": [ ... ],
+     *   "credential_configurations": [ ... ],
      *   "grants": {
      *     <span style="color:darkred;">"urn:ietf:params:oauth:grant-type:pre-authorized_code"</span>: { ... }
      *   }
@@ -679,7 +720,7 @@ public class CredentialOfferInfo implements Serializable
      * <pre>
      * {
      *   "credential_issuer": "...",
-     *   "credentials": [ ... ],
+     *   "credential_configurations": [ ... ],
      *   "grants": {
      *     "urn:ietf:params:oauth:grant-type:pre-authorized_code": {
      *       <span style="color:darkred;">"pre-authorized_code": "..."</span>
@@ -709,7 +750,7 @@ public class CredentialOfferInfo implements Serializable
      * <pre>
      * {
      *   "credential_issuer": "...",
-     *   "credentials": [ ... ],
+     *   "credential_configurations": [ ... ],
      *   "grants": {
      *     "urn:ietf:params:oauth:grant-type:pre-authorized_code": {
      *       <span style="color:darkred;">"pre-authorized_code": "..."</span>
@@ -730,118 +771,6 @@ public class CredentialOfferInfo implements Serializable
     public CredentialOfferInfo setPreAuthorizedCode(String code)
     {
         this.preAuthorizedCode = code;
-
-        return this;
-    }
-
-
-    /**
-     * Get the value of the {@code user_pin_required} property in the
-     * {@code urn:ietf:params:oauth:grant-type:pre-authorized_code} object in
-     * the {@code grants} object.
-     *
-     * <blockquote>
-     * <pre>
-     * {
-     *   "credential_issuer": "...",
-     *   "credentials": [ ... ],
-     *   "grants": {
-     *     "urn:ietf:params:oauth:grant-type:pre-authorized_code": {
-     *       "pre-authorized_code": "...",
-     *       <span style="color:darkred;">"user_pin_required": true</span>
-     *     }
-     *   }
-     * }
-     * </pre>
-     * </blockquote>
-     *
-     * <p>
-     * Note that this method returns {@code false} also in the case where the
-     * {@code user_pin_required} property is not included.
-     * </p>
-     *
-     * @return
-     *         The value of the {@code user_pin_required} property in the
-     *         {@code urn:ietf:params:oauth:grant-type:pre-authorized_code}
-     *         object in the {@code grants} object.
-     */
-    public boolean isUserPinRequired()
-    {
-        return userPinRequired;
-    }
-
-
-    /**
-     * Set the value of the {@code user_pin_required} property in the
-     * {@code urn:ietf:params:oauth:grant-type:pre-authorized_code} object in
-     * the {@code grants} object.
-     *
-     * <blockquote>
-     * <pre>
-     * {
-     *   "credential_issuer": "...",
-     *   "credentials": [ ... ],
-     *   "grants": {
-     *     "urn:ietf:params:oauth:grant-type:pre-authorized_code": {
-     *       "pre-authorized_code": "...",
-     *       <span style="color:darkred;">"user_pin_required": true</span>
-     *     }
-     *   }
-     * }
-     * </pre>
-     * </blockquote>
-     *
-     * @param required
-     *         {@code true} to indicate that the value of the
-     *         {@code user_pin_required} property is {@code true}.
-     *         {@code false} to indicate that the value of the property
-     *         is {@code false} or that the property is missing.
-     *
-     * @return
-     *         {@code this} object.
-     */
-    public CredentialOfferInfo setUserPinRequired(boolean required)
-    {
-        this.userPinRequired = required;
-
-        return this;
-    }
-
-
-    /**
-     * Get the value of the user PIN associated with the credential offer.
-     *
-     * <p>
-     * The value consists of maximum 8 numeric characters. For example,
-     * {@code 493536}.
-     * </p>
-     *
-     * @return
-     *         The value of the user PIN.
-     */
-    public String getUserPin()
-    {
-        return userPin;
-    }
-
-
-    /**
-     * Set the value of the user PIN associated with the credential offer.
-     *
-     * <p>
-     * The value consists of maximum 8 numeric characters. For example,
-     * {@code 493536}.
-     * </p>
-     *
-     * @param pin
-     *         The value of the user PIN.
-     *
-     * @return
-     *         {@code this} object.
-     */
-    public CredentialOfferInfo setUserPin(String pin)
-    {
-        this.userPin = pin;
 
         return this;
     }
@@ -1140,6 +1069,106 @@ public class CredentialOfferInfo implements Serializable
     public CredentialOfferInfo setAcr(String acr)
     {
         this.acr = acr;
+
+        return this;
+    }
+
+
+    /**
+     * Get the transaction code.
+     *
+     * @return
+     *         The transaction code.
+     *
+     * @since 3.91
+     */
+    public String getTxCode()
+    {
+        return txCode;
+    }
+
+
+    /**
+     * Set the transaction code.
+     *
+     * @param txCode
+     *         The transaction code.
+     *
+     * @return
+     *         {@code this} object.
+     *
+     * @since 3.91
+     */
+    public CredentialOfferInfo setTxCode(String txCode)
+    {
+        this.txCode = txCode;
+
+        return this;
+    }
+
+
+    /**
+     * Get the input mode of the transaction code.
+     *
+     * @return
+     *         The input mode of the transaction code.
+     *
+     * @since 3.91
+     */
+    public String getTxCodeInputMode()
+    {
+        return txCodeInputMode;
+    }
+
+
+    /**
+     * Set the input mode of the transaction code.
+     *
+     * @param inputMode
+     *         The input mode of the transaction code.
+     *         Such as "{@code numeric}" and "{@code text}".
+     *
+     * @return
+     *         {@code this} object.
+     *
+     * @since 3.91
+     */
+    public CredentialOfferInfo setTxCodeInputMode(String inputMode)
+    {
+        this.txCodeInputMode = inputMode;
+
+        return this;
+    }
+
+
+    /**
+     * Get the description of the transaction code.
+     *
+     * @return
+     *         The description of the transaction code.
+     *
+     * @since 3.91
+     */
+    public String getTxCodeDescription()
+    {
+        return txCodeDescription;
+    }
+
+
+    /**
+     * Set the description of the transaction code.
+     *
+     * @param description
+     *         The description of the transaction code.
+     *
+     * @return
+     *         {@code this} object.
+     *
+     * @since 3.91
+     */
+    public CredentialOfferInfo setTxCodeDescription(String description)
+    {
+        this.txCodeDescription = description;
 
         return this;
     }

--- a/src/main/java/com/authlete/common/dto/IntrospectionResponse.java
+++ b/src/main/java/com/authlete/common/dto/IntrospectionResponse.java
@@ -1858,13 +1858,13 @@ public class IntrospectionResponse extends ApiResponse
      *
      * <ol>
      * <li>
-     * The "{@code credentials}" property in the credential offer that was used
-     * when the access token was issued. A credential offer may contain either
-     * or both an issuer state and a pre-authorized code. The issuer state can
-     * be used as the value of the "{@code issuer_state}" request parameter of
-     * an authorization request. The pre-authorized code can be used as the
-     * value of the "{@code pre-authorized_code}" request parameter of a token
-     * request whose "{@code grant_type}" is
+     * The "{@code credential_configurations}" property in the credential offer
+     * that was used when the access token was issued. A credential offer may
+     * contain either or both an issuer state and a pre-authorized code. The
+     * issuer state can be used as the value of the "{@code issuer_state}"
+     * request parameter of an authorization request. The pre-authorized code
+     * can be used as the value of the "{@code pre-authorized_code}" request
+     * parameter of a token request whose "{@code grant_type}" is
      * "{@code urn:ietf:params:oauth:grant-type:pre-authorized_code}".
      *
      * <li>
@@ -1875,10 +1875,10 @@ public class IntrospectionResponse extends ApiResponse
      * Rich Authorization Requests</a>.
      *
      * <li>
-     * The content of an entry in the "{@code credentials_supported}" metadata
-     * of the credential issuer. The identifier of an entry in the
-     * "{@code credentials_supported}" metadata can be used as a value in the
-     * "{@code scope}" request parameter.
+     * The content of an entry in the "{@code credential_configurations_supported}"
+     * metadata of the credential issuer. The "{@code scope}" property of an entry
+     * in the "{@code credential_configurations_supported}" metadata can be used
+     * as a value in the "{@code scope}" request parameter.
      * </ol>
      *
      * <p>

--- a/src/main/java/com/authlete/common/dto/Service.java
+++ b/src/main/java/com/authlete/common/dto/Service.java
@@ -1709,7 +1709,9 @@ public class Service implements Serializable
      *
      * @since 3.59
      * @since Authlete 3.0
+     * @deprecated
      */
+    @Deprecated
     private int userPinLength;
 
 
@@ -10651,6 +10653,12 @@ public class Service implements Serializable
      * Authlete server is used as the default value.
      * </p>
      *
+     * <p>
+     * NOTE: This property has been deprecated due to a breaking change of the
+     * OID4VCI specification. The {@code /vci/offer/create} API no longer
+     * recognizes the {@code userPinLength} request parameter.
+     * </p>
+     *
      * @return
      *         The default length of user PINs.
      *
@@ -10658,7 +10666,10 @@ public class Service implements Serializable
      * @since Authlete 3.0
      *
      * @see CredentialOfferCreateRequest#getUserPinLength()
+     *
+     * @deprecated
      */
+    @Deprecated
     public int getUserPinLength()
     {
         return userPinLength;
@@ -10679,6 +10690,12 @@ public class Service implements Serializable
      * Authlete server is used as the default value.
      * </p>
      *
+     * <p>
+     * NOTE: This property has been deprecated due to a breaking change of the
+     * OID4VCI specification. The {@code /vci/offer/create} API no longer
+     * recognizes the {@code userPinLength} request parameter.
+     * </p>
+     *
      * @param length
      *         The default length of user PINs.
      *
@@ -10689,7 +10706,10 @@ public class Service implements Serializable
      * @since Authlete 3.0
      *
      * @see CredentialOfferCreateRequest#setUserPinLength(int)
+     *
+     * @deprecated
      */
+    @Deprecated
     public Service setUserPinLength(int length)
     {
         this.userPinLength = length;


### PR DESCRIPTION
To cope with the following breaking changes:

- The `credentials` property in a credential offer has been renamed to `credential_configurations`.
- The `user_pin_required` boolean property in a credential offer has been replaced with the `tx_code` JSON object.
- The `credentials_supported` credential issuer metadata has been renamed to `credential_configurations_supported`.
- The `user_pin` parameter in a token request has been replaced with `tx_code`.