### PR TITLE
[bugfix] NPE thrown improperly in AuthleteApiImpl class

### DIFF
--- a/src/main/java/com/authlete/common/api/AuthleteApiImpl.java
+++ b/src/main/java/com/authlete/common/api/AuthleteApiImpl.java
@@ -698,6 +698,10 @@ class AuthleteApiImpl implements AuthleteApi
         // Error message.
         String message = cause.getMessage();
 
+        if (ctx == null) {
+            return new AuthleteApiException(message, cause);
+        }
+
         HttpURLConnection con = ctx.connection();
 
         if (con == null)


### PR DESCRIPTION
Hi, Authlete developers

I'm an Authlete user and I fix a problem in which a `NullPointerException` would be thrown improperly if the connection failed to open when calling Authlete APIs.

Please consider if you want to merge this fix.

## Why does it need fixed?

Developers expect an `AuthleteApiException` to be thrown when an error occurs in an API call.
In fact, however, a `NullPointerException` is thrown and the exception could not handle properly.

In addition, the root cause is unknown because the error is occurring during generating an `AuthleteApiException` exception instance.

## How will it be fixed?

I simply add a checking for null.