### PR TITLE
Add /api/info endpoint to AuthleteApi

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.authlete</groupId>
     <artifactId>authlete-java-common</artifactId>
-    <version>3.98-SNAPSHOT</version>
+    <version>3.99-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>

--- a/src/main/java/com/authlete/common/api/AuthleteApi.java
+++ b/src/main/java/com/authlete/common/api/AuthleteApi.java
@@ -84,6 +84,7 @@ import com.authlete.common.dto.HskListResponse;
 import com.authlete.common.dto.HskResponse;
 import com.authlete.common.dto.IDTokenReissueRequest;
 import com.authlete.common.dto.IDTokenReissueResponse;
+import com.authlete.common.dto.InfoResponse;
 import com.authlete.common.dto.IntrospectionRequest;
 import com.authlete.common.dto.IntrospectionResponse;
 import com.authlete.common.dto.JoseVerifyRequest;
@@ -111,13 +112,13 @@ import com.authlete.common.dto.TokenRequest;
 import com.authlete.common.dto.TokenResponse;
 import com.authlete.common.dto.TokenRevokeRequest;
 import com.authlete.common.dto.TokenRevokeResponse;
-import com.authlete.common.types.TokenStatus;
 import com.authlete.common.dto.TokenUpdateRequest;
 import com.authlete.common.dto.TokenUpdateResponse;
 import com.authlete.common.dto.UserInfoIssueRequest;
 import com.authlete.common.dto.UserInfoIssueResponse;
 import com.authlete.common.dto.UserInfoRequest;
 import com.authlete.common.dto.UserInfoResponse;
+import com.authlete.common.types.TokenStatus;
 
 
 /**
@@ -2144,4 +2145,15 @@ public interface AuthleteApi
      */
     TokenCreateBatchStatusResponse getTokenCreateBatchStatus(
             TokenCreateBatchStatusRequest request) throws AuthleteApiException;
+
+    /**
+     * Call Authlete's {@code /api/info} API.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 3.99
+     * @since Authlete 2.3
+     */
+    InfoResponse info() throws AuthleteApiException;
 }

--- a/src/main/java/com/authlete/common/api/AuthleteApiImpl.java
+++ b/src/main/java/com/authlete/common/api/AuthleteApiImpl.java
@@ -131,6 +131,7 @@ class AuthleteApiImpl implements AuthleteApi
     private static final String VCI_DEFERRED_PARSE_API_PATH               = "/api/vci/deferred/parse";
     private static final String VCI_DEFERRED_ISSUE_API_PATH               = "/api/vci/deferred/issue";
     private static final String ID_TOKEN_REISSUE_API_PATH                 = "/api/idtoken/reissue";
+    private static final String INFO_API_PATH                             = "/api/info";
 
     private final String mBaseUrl;
     private final BasicCredentials mServiceOwnerCredentials;
@@ -1811,5 +1812,13 @@ class AuthleteApiImpl implements AuthleteApi
         // This is unavailable in Authlete 2.x and older versions.
         throw new AuthleteApiException(
                 "This method can't be invoked since the corresponding API is not supported.");
+    }
+
+    @Override
+    public InfoResponse info() throws AuthleteApiException
+    {
+        return callServiceGetApi(
+                INFO_API_PATH,
+                InfoResponse.class);
     }
 }

--- a/src/main/java/com/authlete/common/dto/InfoResponse.java
+++ b/src/main/java/com/authlete/common/dto/InfoResponse.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2023 Authlete, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.authlete.common.dto;
+
+
+import java.util.List;
+
+
+/**
+ * Response from Authlete's {@code /api/info} API.
+ *
+ * <p>
+ * The API is used to get the server information
+ * from the {@code /api/info} API.
+ * </p>
+ *
+ * @since 3.99
+ */
+public class InfoResponse extends ApiResponse
+{
+    private static final long serialVersionUID = 1L;
+
+
+    private List<String> features;
+    private String version;
+
+    /**
+     * Get the list of features retrieved from the /api/info API.
+     *
+     * @return
+     *         The list of features retrieved from the /api/info API.
+     */
+    public List<String> getFeatures()
+    {
+        return features;
+    }
+
+    /**
+     * Sets the list of features for the {@link InfoResponse} object.
+     *
+     * @param features
+     *         The list of features to set. Each feature is represented as a {@link String}.
+     *
+     * @return
+     *         {@code this} object.
+     */
+    public InfoResponse setFeatures(List<String> features)
+    {
+        this.features = features;
+
+        return this;
+    }
+
+    /**
+     * Retrieves the version of the Authlete API server.
+     *
+     * @return
+     *         The version of the Authlete API server as a string.
+     */
+    public String getVersion()
+    {
+        return version;
+    }
+
+    /**
+     * Set the version of the response.
+     *
+     * @param version
+     *         The version to set. For example, "3.0.0".
+     *
+     * @return
+     *         {@code this} object.
+     */
+    public InfoResponse setVersion(String version)
+    {
+        this.version = version;
+
+        return this;
+    }
+}


### PR DESCRIPTION
This update adds the `/api/info` endpoint to `AuthleteApi`, providing a way to retrieve server information.

A new method `info()` and corresponding `InfoResponse` DTO  have been added for this purpose.

The version in `pom.xml`  has been updated to `3.99`.