### PR TITLE
[feature] OAuth 2.0 Attestation-Based Client Authentication

### DIFF
--- a/CHANGES.ja.md
+++ b/CHANGES.ja.md
@@ -1,6 +1,37 @@
 変更点
 ======
 
+- `BackchannelAuthenticationRequest` クラス
+    * `getOauthClientAttestation()` メソッドを追加。
+    * `setOauthClientAttestation(String)` メソッドを追加。
+    * `getOauthClientAttestationPop()` メソッドを追加。
+    * `setOauthClientAttestationPop(String)` メソッドを追加。
+
+- `DeviceAuthorizationRequest` クラス
+    * `getOauthClientAttestation()` メソッドを追加。
+    * `setOauthClientAttestation(String)` メソッドを追加。
+    * `getOauthClientAttestationPop()` メソッドを追加。
+    * `setOauthClientAttestationPop(String)` メソッドを追加。
+
+- `PushedAuthReqRequest` クラス
+    * `getOauthClientAttestation()` メソッドを追加。
+    * `setOauthClientAttestation(String)` メソッドを追加。
+    * `getOauthClientAttestationPop()` メソッドを追加。
+    * `setOauthClientAttestationPop(String)` メソッドを追加。
+
+- `RevocationRequest` クラス
+    * `getOauthClientAttestation()` メソッドを追加。
+    * `setOauthClientAttestation(String)` メソッドを追加。
+    * `getOauthClientAttestationPop()` メソッドを追加。
+    * `setOauthClientAttestationPop(String)` メソッドを追加。
+
+- `TokenRequest` クラス
+    * `getOauthClientAttestation()` メソッドを追加。
+    * `setOauthClientAttestation(String)` メソッドを追加。
+    * `getOauthClientAttestationPop()` メソッドを追加。
+    * `setOauthClientAttestationPop(String)` メソッドを追加。
+
+
 4.2 (2024 年 06 月 16 日)
 -------------------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,37 @@
 CHANGES
 =======
 
+- `BackchannelAuthenticationRequest` class
+    * Added `getOauthClientAttestation()` method.
+    * Added `setOauthClientAttestation(String)` method.
+    * Added `getOauthClientAttestationPop()` method.
+    * Added `setOauthClientAttestationPop(String)` method.
+
+- `DeviceAuthorizationRequest` class
+    * Added `getOauthClientAttestation()` method.
+    * Added `setOauthClientAttestation(String)` method.
+    * Added `getOauthClientAttestationPop()` method.
+    * Added `setOauthClientAttestationPop(String)` method.
+
+- `PushedAuthReqRequest` class
+    * Added `getOauthClientAttestation()` method.
+    * Added `setOauthClientAttestation(String)` method.
+    * Added `getOauthClientAttestationPop()` method.
+    * Added `setOauthClientAttestationPop(String)` method.
+
+- `RevocationRequest` class
+    * Added `getOauthClientAttestation()` method.
+    * Added `setOauthClientAttestation(String)` method.
+    * Added `getOauthClientAttestationPop()` method.
+    * Added `setOauthClientAttestationPop(String)` method.
+
+- `TokenRequest` class
+    * Added `getOauthClientAttestation()` method.
+    * Added `setOauthClientAttestation(String)` method.
+    * Added `getOauthClientAttestationPop()` method.
+    * Added `setOauthClientAttestationPop(String)` method.
+
+
 4.2 (2024-06-16)
 ----------------
 

--- a/src/main/java/com/authlete/common/dto/BackchannelAuthenticationRequest.java
+++ b/src/main/java/com/authlete/common/dto/BackchannelAuthenticationRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Authlete, Inc.
+ * Copyright (C) 2018-2024 Authlete, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -97,6 +97,26 @@ import com.authlete.common.web.URLCoder;
  * </p>
  * </dd>
  *
+ * <dt><b><code>oauthClientAttestation</code></b> (OPTIONAL; Authlete 3.0 onwards)</dt>
+ * <dd>
+ * <p>
+ * The value of the {@code OAuth-Client-Attestation} HTTP header, which is
+ * defined in the specification of <a href=
+ * "https://datatracker.ietf.org/doc/draft-ietf-oauth-attestation-based-client-auth/"
+ * >OAuth 2.0 Attestation-Based Client Authentication</a>.
+ * </p>
+ * </dd>
+ *
+ * <dt><b><code>oauthClientAttestationPop</code></b> (OPTIONAL; Authlete 3.0 onwards)</dt>
+ * <dd>
+ * <p>
+ * The value of the {@code OAuth-Client-Attestation-PoP} HTTP header, which is
+ * defined in the specification of <a href=
+ * "https://datatracker.ietf.org/doc/draft-ietf-oauth-attestation-based-client-auth/"
+ * >OAuth 2.0 Attestation-Based Client Authentication</a>.
+ * </p>
+ * </dd>
+ *
  * </dl>
  * </blockquote>
  *
@@ -104,7 +124,7 @@ import com.authlete.common.web.URLCoder;
  */
 public class BackchannelAuthenticationRequest implements Serializable
 {
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 2L;
 
 
     /**
@@ -135,6 +155,30 @@ public class BackchannelAuthenticationRequest implements Serializable
      * Client certificate path.
      */
     private String[] clientCertificatePath;
+
+
+    /**
+     * The value of the {@code OAuth-Client-Attestation} HTTP header.
+     *
+     * @since 4.3
+     * @since Authlete 3.0
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/draft-ietf-oauth-attestation-based-client-auth/"
+     *      >OAuth 2.0 Attestation-Based Client Authentication</a>
+     */
+    private String oauthClientAttestation;
+
+
+    /**
+     * The value of the {@code OAuth-Client-Attestation-PoP} HTTP header.
+     *
+     * @since 4.3
+     * @since Authlete 3.0
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/draft-ietf-oauth-attestation-based-client-auth/"
+     *      >OAuth 2.0 Attestation-Based Client Authentication</a>
+     */
+    private String oauthClientAttestationPop;
 
 
     /**
@@ -317,6 +361,88 @@ public class BackchannelAuthenticationRequest implements Serializable
     public BackchannelAuthenticationRequest setClientCertificatePath(String[] path)
     {
         this.clientCertificatePath = path;
+
+        return this;
+    }
+
+
+    /**
+     * Get the value of the {@code OAuth-Client-Attestation} HTTP header.
+     *
+     * @return
+     *         The value of the {@code OAuth-Client-Attestation} HTTP header.
+     *
+     * @since 4.3
+     * @since Authlete 3.0
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/draft-ietf-oauth-attestation-based-client-auth/"
+     *      >OAuth 2.0 Attestation-Based Client Authentication</a>
+     */
+    public String getOauthClientAttestation()
+    {
+        return oauthClientAttestation;
+    }
+
+
+    /**
+     * Set the value of the {@code OAuth-Client-Attestation} HTTP header.
+     *
+     * @param jwt
+     *         The value of the {@code OAuth-Client-Attestation} HTTP header.
+     *
+     * @return
+     *         {@code this} object.
+     *
+     * @since 4.3
+     * @since Authlete 3.0
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/draft-ietf-oauth-attestation-based-client-auth/"
+     *      >OAuth 2.0 Attestation-Based Client Authentication</a>
+     */
+    public BackchannelAuthenticationRequest setOauthClientAttestation(String jwt)
+    {
+        this.oauthClientAttestation = jwt;
+
+        return this;
+    }
+
+
+    /**
+     * Get the value of the {@code OAuth-Client-Attestation-PoP} HTTP header.
+     *
+     * @return
+     *         The value of the {@code OAuth-Client-Attestation-PoP} HTTP header.
+     *
+     * @since 4.3
+     * @since Authlete 3.0
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/draft-ietf-oauth-attestation-based-client-auth/"
+     *      >OAuth 2.0 Attestation-Based Client Authentication</a>
+     */
+    public String getOauthClientAttestationPop()
+    {
+        return oauthClientAttestationPop;
+    }
+
+
+    /**
+     * Set the value of the {@code OAuth-Client-Attestation-PoP} HTTP header.
+     *
+     * @param jwt
+     *         The value of the {@code OAuth-Client-Attestation-PoP} HTTP header.
+     *
+     * @return
+     *         {@code this} object.
+     *
+     * @since 4.3
+     * @since Authlete 3.0
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/draft-ietf-oauth-attestation-based-client-auth/"
+     *      >OAuth 2.0 Attestation-Based Client Authentication</a>
+     */
+    public BackchannelAuthenticationRequest setOauthClientAttestationPop(String jwt)
+    {
+        this.oauthClientAttestationPop = jwt;
 
         return this;
     }

--- a/src/main/java/com/authlete/common/dto/DeviceAuthorizationRequest.java
+++ b/src/main/java/com/authlete/common/dto/DeviceAuthorizationRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Authlete, Inc.
+ * Copyright (C) 2019-2024 Authlete, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -97,6 +97,26 @@ import com.authlete.common.web.URLCoder;
  * </p>
  * </dd>
  *
+ * <dt><b><code>oauthClientAttestation</code></b> (OPTIONAL; Authlete 3.0 onwards)</dt>
+ * <dd>
+ * <p>
+ * The value of the {@code OAuth-Client-Attestation} HTTP header, which is
+ * defined in the specification of <a href=
+ * "https://datatracker.ietf.org/doc/draft-ietf-oauth-attestation-based-client-auth/"
+ * >OAuth 2.0 Attestation-Based Client Authentication</a>.
+ * </p>
+ * </dd>
+ *
+ * <dt><b><code>oauthClientAttestationPop</code></b> (OPTIONAL; Authlete 3.0 onwards)</dt>
+ * <dd>
+ * <p>
+ * The value of the {@code OAuth-Client-Attestation-PoP} HTTP header, which is
+ * defined in the specification of <a href=
+ * "https://datatracker.ietf.org/doc/draft-ietf-oauth-attestation-based-client-auth/"
+ * >OAuth 2.0 Attestation-Based Client Authentication</a>.
+ * </p>
+ * </dd>
+ *
  * </dl>
  * </blockquote>
  *
@@ -104,7 +124,7 @@ import com.authlete.common.web.URLCoder;
  */
 public class DeviceAuthorizationRequest implements Serializable
 {
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 2L;
 
 
     /**
@@ -135,6 +155,30 @@ public class DeviceAuthorizationRequest implements Serializable
      * Client certificate path.
      */
     private String[] clientCertificatePath;
+
+
+    /**
+     * The value of the {@code OAuth-Client-Attestation} HTTP header.
+     *
+     * @since 4.3
+     * @since Authlete 3.0
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/draft-ietf-oauth-attestation-based-client-auth/"
+     *      >OAuth 2.0 Attestation-Based Client Authentication</a>
+     */
+    private String oauthClientAttestation;
+
+
+    /**
+     * The value of the {@code OAuth-Client-Attestation-PoP} HTTP header.
+     *
+     * @since 4.3
+     * @since Authlete 3.0
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/draft-ietf-oauth-attestation-based-client-auth/"
+     *      >OAuth 2.0 Attestation-Based Client Authentication</a>
+     */
+    private String oauthClientAttestationPop;
 
 
     /**
@@ -317,6 +361,88 @@ public class DeviceAuthorizationRequest implements Serializable
     public DeviceAuthorizationRequest setClientCertificatePath(String[] path)
     {
         this.clientCertificatePath = path;
+
+        return this;
+    }
+
+
+    /**
+     * Get the value of the {@code OAuth-Client-Attestation} HTTP header.
+     *
+     * @return
+     *         The value of the {@code OAuth-Client-Attestation} HTTP header.
+     *
+     * @since 4.3
+     * @since Authlete 3.0
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/draft-ietf-oauth-attestation-based-client-auth/"
+     *      >OAuth 2.0 Attestation-Based Client Authentication</a>
+     */
+    public String getOauthClientAttestation()
+    {
+        return oauthClientAttestation;
+    }
+
+
+    /**
+     * Set the value of the {@code OAuth-Client-Attestation} HTTP header.
+     *
+     * @param jwt
+     *         The value of the {@code OAuth-Client-Attestation} HTTP header.
+     *
+     * @return
+     *         {@code this} object.
+     *
+     * @since 4.3
+     * @since Authlete 3.0
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/draft-ietf-oauth-attestation-based-client-auth/"
+     *      >OAuth 2.0 Attestation-Based Client Authentication</a>
+     */
+    public DeviceAuthorizationRequest setOauthClientAttestation(String jwt)
+    {
+        this.oauthClientAttestation = jwt;
+
+        return this;
+    }
+
+
+    /**
+     * Get the value of the {@code OAuth-Client-Attestation-PoP} HTTP header.
+     *
+     * @return
+     *         The value of the {@code OAuth-Client-Attestation-PoP} HTTP header.
+     *
+     * @since 4.3
+     * @since Authlete 3.0
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/draft-ietf-oauth-attestation-based-client-auth/"
+     *      >OAuth 2.0 Attestation-Based Client Authentication</a>
+     */
+    public String getOauthClientAttestationPop()
+    {
+        return oauthClientAttestationPop;
+    }
+
+
+    /**
+     * Set the value of the {@code OAuth-Client-Attestation-PoP} HTTP header.
+     *
+     * @param jwt
+     *         The value of the {@code OAuth-Client-Attestation-PoP} HTTP header.
+     *
+     * @return
+     *         {@code this} object.
+     *
+     * @since 4.3
+     * @since Authlete 3.0
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/draft-ietf-oauth-attestation-based-client-auth/"
+     *      >OAuth 2.0 Attestation-Based Client Authentication</a>
+     */
+    public DeviceAuthorizationRequest setOauthClientAttestationPop(String jwt)
+    {
+        this.oauthClientAttestationPop = jwt;
 
         return this;
     }

--- a/src/main/java/com/authlete/common/dto/PushedAuthReqRequest.java
+++ b/src/main/java/com/authlete/common/dto/PushedAuthReqRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Authlete, Inc.
+ * Copyright (C) 2019-2024 Authlete, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -133,6 +133,26 @@ import java.io.Serializable;
  * </p>
  * </dd>
  *
+ * <dt><b><code>oauthClientAttestation</code></b> (OPTIONAL; Authlete 3.0 onwards)</dt>
+ * <dd>
+ * <p>
+ * The value of the {@code OAuth-Client-Attestation} HTTP header, which is
+ * defined in the specification of <a href=
+ * "https://datatracker.ietf.org/doc/draft-ietf-oauth-attestation-based-client-auth/"
+ * >OAuth 2.0 Attestation-Based Client Authentication</a>.
+ * </p>
+ * </dd>
+ *
+ * <dt><b><code>oauthClientAttestationPop</code></b> (OPTIONAL; Authlete 3.0 onwards)</dt>
+ * <dd>
+ * <p>
+ * The value of the {@code OAuth-Client-Attestation-PoP} HTTP header, which is
+ * defined in the specification of <a href=
+ * "https://datatracker.ietf.org/doc/draft-ietf-oauth-attestation-based-client-auth/"
+ * >OAuth 2.0 Attestation-Based Client Authentication</a>.
+ * </p>
+ * </dd>
+ *
  * </dl>
  * </blockquote>
  *
@@ -140,7 +160,7 @@ import java.io.Serializable;
  */
 public class PushedAuthReqRequest implements Serializable
 {
-    private static final long serialVersionUID = 2L;
+    private static final long serialVersionUID = 3L;
 
 
     /**
@@ -199,6 +219,30 @@ public class PushedAuthReqRequest implements Serializable
      * @since Authlete 3.0
      */
     private boolean dpopNonceRequired;
+
+
+    /**
+     * The value of the {@code OAuth-Client-Attestation} HTTP header.
+     *
+     * @since 4.3
+     * @since Authlete 3.0
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/draft-ietf-oauth-attestation-based-client-auth/"
+     *      >OAuth 2.0 Attestation-Based Client Authentication</a>
+     */
+    private String oauthClientAttestation;
+
+
+    /**
+     * The value of the {@code OAuth-Client-Attestation-PoP} HTTP header.
+     *
+     * @since 4.3
+     * @since Authlete 3.0
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/draft-ietf-oauth-attestation-based-client-auth/"
+     *      >OAuth 2.0 Attestation-Based Client Authentication</a>
+     */
+    private String oauthClientAttestationPop;
 
 
     /**
@@ -597,6 +641,88 @@ public class PushedAuthReqRequest implements Serializable
     public PushedAuthReqRequest setDpopNonceRequired(boolean required)
     {
         this.dpopNonceRequired = required;
+
+        return this;
+    }
+
+
+    /**
+     * Get the value of the {@code OAuth-Client-Attestation} HTTP header.
+     *
+     * @return
+     *         The value of the {@code OAuth-Client-Attestation} HTTP header.
+     *
+     * @since 4.3
+     * @since Authlete 3.0
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/draft-ietf-oauth-attestation-based-client-auth/"
+     *      >OAuth 2.0 Attestation-Based Client Authentication</a>
+     */
+    public String getOauthClientAttestation()
+    {
+        return oauthClientAttestation;
+    }
+
+
+    /**
+     * Set the value of the {@code OAuth-Client-Attestation} HTTP header.
+     *
+     * @param jwt
+     *         The value of the {@code OAuth-Client-Attestation} HTTP header.
+     *
+     * @return
+     *         {@code this} object.
+     *
+     * @since 4.3
+     * @since Authlete 3.0
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/draft-ietf-oauth-attestation-based-client-auth/"
+     *      >OAuth 2.0 Attestation-Based Client Authentication</a>
+     */
+    public PushedAuthReqRequest setOauthClientAttestation(String jwt)
+    {
+        this.oauthClientAttestation = jwt;
+
+        return this;
+    }
+
+
+    /**
+     * Get the value of the {@code OAuth-Client-Attestation-PoP} HTTP header.
+     *
+     * @return
+     *         The value of the {@code OAuth-Client-Attestation-PoP} HTTP header.
+     *
+     * @since 4.3
+     * @since Authlete 3.0
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/draft-ietf-oauth-attestation-based-client-auth/"
+     *      >OAuth 2.0 Attestation-Based Client Authentication</a>
+     */
+    public String getOauthClientAttestationPop()
+    {
+        return oauthClientAttestationPop;
+    }
+
+
+    /**
+     * Set the value of the {@code OAuth-Client-Attestation-PoP} HTTP header.
+     *
+     * @param jwt
+     *         The value of the {@code OAuth-Client-Attestation-PoP} HTTP header.
+     *
+     * @return
+     *         {@code this} object.
+     *
+     * @since 4.3
+     * @since Authlete 3.0
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/draft-ietf-oauth-attestation-based-client-auth/"
+     *      >OAuth 2.0 Attestation-Based Client Authentication</a>
+     */
+    public PushedAuthReqRequest setOauthClientAttestationPop(String jwt)
+    {
+        this.oauthClientAttestationPop = jwt;
 
         return this;
     }

--- a/src/main/java/com/authlete/common/dto/RevocationRequest.java
+++ b/src/main/java/com/authlete/common/dto/RevocationRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2021 Authlete, Inc.
+ * Copyright (C) 2015-2024 Authlete, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,6 +72,43 @@ import com.authlete.common.web.URLCoder;
  * value should be extracted and set to this parameter.
  * </p>
  * </dd>
+ *
+ * <dt><b><code>clientCertificate</code></b> (OPTIONAL)</dt>
+ * <dd>
+ * <p>
+ * The client certification used in the TLS connection between the client
+ * application and the revocation endpoint.
+ * </p>
+ * </dd>
+ *
+ * <dt><b><code>clientCertificatePath</code></b> (OPTIONAL)</dt>
+ * <dd>
+ * <p>
+ * The client certificate path presented by the client during client
+ * authentication. Each element is a string in PEM format.
+ * </p>
+ * </dd>
+ *
+ * <dt><b><code>oauthClientAttestation</code></b> (OPTIONAL; Authlete 3.0 onwards)</dt>
+ * <dd>
+ * <p>
+ * The value of the {@code OAuth-Client-Attestation} HTTP header, which is
+ * defined in the specification of <a href=
+ * "https://datatracker.ietf.org/doc/draft-ietf-oauth-attestation-based-client-auth/"
+ * >OAuth 2.0 Attestation-Based Client Authentication</a>.
+ * </p>
+ * </dd>
+ *
+ * <dt><b><code>oauthClientAttestationPop</code></b> (OPTIONAL; Authlete 3.0 onwards)</dt>
+ * <dd>
+ * <p>
+ * The value of the {@code OAuth-Client-Attestation-PoP} HTTP header, which is
+ * defined in the specification of <a href=
+ * "https://datatracker.ietf.org/doc/draft-ietf-oauth-attestation-based-client-auth/"
+ * >OAuth 2.0 Attestation-Based Client Authentication</a>.
+ * </p>
+ * </dd>
+ *
  * </dl>
  * </blockquote>
  *
@@ -103,7 +140,7 @@ import com.authlete.common.web.URLCoder;
  */
 public class RevocationRequest implements Serializable
 {
-    private static final long serialVersionUID = 3L;
+    private static final long serialVersionUID = 4L;
 
 
     /**
@@ -134,6 +171,30 @@ public class RevocationRequest implements Serializable
      * Client certificate path.
      */
     private String[] clientCertificatePath;
+
+
+    /**
+     * The value of the {@code OAuth-Client-Attestation} HTTP header.
+     *
+     * @since 4.3
+     * @since Authlete 3.0
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/draft-ietf-oauth-attestation-based-client-auth/"
+     *      >OAuth 2.0 Attestation-Based Client Authentication</a>
+     */
+    private String oauthClientAttestation;
+
+
+    /**
+     * The value of the {@code OAuth-Client-Attestation-PoP} HTTP header.
+     *
+     * @since 4.3
+     * @since Authlete 3.0
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/draft-ietf-oauth-attestation-based-client-auth/"
+     *      >OAuth 2.0 Attestation-Based Client Authentication</a>
+     */
+    private String oauthClientAttestationPop;
 
 
     /**
@@ -296,6 +357,88 @@ public class RevocationRequest implements Serializable
     public RevocationRequest setClientCertificatePath(String[] path)
     {
         this.clientCertificatePath = path;
+
+        return this;
+    }
+
+
+    /**
+     * Get the value of the {@code OAuth-Client-Attestation} HTTP header.
+     *
+     * @return
+     *         The value of the {@code OAuth-Client-Attestation} HTTP header.
+     *
+     * @since 4.3
+     * @since Authlete 3.0
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/draft-ietf-oauth-attestation-based-client-auth/"
+     *      >OAuth 2.0 Attestation-Based Client Authentication</a>
+     */
+    public String getOauthClientAttestation()
+    {
+        return oauthClientAttestation;
+    }
+
+
+    /**
+     * Set the value of the {@code OAuth-Client-Attestation} HTTP header.
+     *
+     * @param jwt
+     *         The value of the {@code OAuth-Client-Attestation} HTTP header.
+     *
+     * @return
+     *         {@code this} object.
+     *
+     * @since 4.3
+     * @since Authlete 3.0
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/draft-ietf-oauth-attestation-based-client-auth/"
+     *      >OAuth 2.0 Attestation-Based Client Authentication</a>
+     */
+    public RevocationRequest setOauthClientAttestation(String jwt)
+    {
+        this.oauthClientAttestation = jwt;
+
+        return this;
+    }
+
+
+    /**
+     * Get the value of the {@code OAuth-Client-Attestation-PoP} HTTP header.
+     *
+     * @return
+     *         The value of the {@code OAuth-Client-Attestation-PoP} HTTP header.
+     *
+     * @since 4.3
+     * @since Authlete 3.0
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/draft-ietf-oauth-attestation-based-client-auth/"
+     *      >OAuth 2.0 Attestation-Based Client Authentication</a>
+     */
+    public String getOauthClientAttestationPop()
+    {
+        return oauthClientAttestationPop;
+    }
+
+
+    /**
+     * Set the value of the {@code OAuth-Client-Attestation-PoP} HTTP header.
+     *
+     * @param jwt
+     *         The value of the {@code OAuth-Client-Attestation-PoP} HTTP header.
+     *
+     * @return
+     *         {@code this} object.
+     *
+     * @since 4.3
+     * @since Authlete 3.0
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/draft-ietf-oauth-attestation-based-client-auth/"
+     *      >OAuth 2.0 Attestation-Based Client Authentication</a>
+     */
+    public RevocationRequest setOauthClientAttestationPop(String jwt)
+    {
+        this.oauthClientAttestationPop = jwt;
 
         return this;
     }

--- a/src/main/java/com/authlete/common/dto/TokenRequest.java
+++ b/src/main/java/com/authlete/common/dto/TokenRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2023 Authlete, Inc.
+ * Copyright (C) 2014-2024 Authlete, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -167,6 +167,26 @@ import com.authlete.common.web.URLCoder;
  * </p>
  * </dd>
  *
+ * <dt><b><code>oauthClientAttestation</code></b> (OPTIONAL; Authlete 3.0 onwards)</dt>
+ * <dd>
+ * <p>
+ * The value of the {@code OAuth-Client-Attestation} HTTP header, which is
+ * defined in the specification of <a href=
+ * "https://datatracker.ietf.org/doc/draft-ietf-oauth-attestation-based-client-auth/"
+ * >OAuth 2.0 Attestation-Based Client Authentication</a>.
+ * </p>
+ * </dd>
+ *
+ * <dt><b><code>oauthClientAttestationPop</code></b> (OPTIONAL; Authlete 3.0 onwards)</dt>
+ * <dd>
+ * <p>
+ * The value of the {@code OAuth-Client-Attestation-PoP} HTTP header, which is
+ * defined in the specification of <a href=
+ * "https://datatracker.ietf.org/doc/draft-ietf-oauth-attestation-based-client-auth/"
+ * >OAuth 2.0 Attestation-Based Client Authentication</a>.
+ * </p>
+ * </dd>
+ *
  * </dl>
  * </blockquote>
  *
@@ -184,7 +204,7 @@ import com.authlete.common.web.URLCoder;
  */
 public class TokenRequest implements Serializable
 {
-    private static final long serialVersionUID = 10L;
+    private static final long serialVersionUID = 11L;
 
 
     /**
@@ -281,6 +301,30 @@ public class TokenRequest implements Serializable
      * @since Authlete 3.0
      */
     private boolean dpopNonceRequired;
+
+
+    /**
+     * The value of the {@code OAuth-Client-Attestation} HTTP header.
+     *
+     * @since 4.3
+     * @since Authlete 3.0
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/draft-ietf-oauth-attestation-based-client-auth/"
+     *      >OAuth 2.0 Attestation-Based Client Authentication</a>
+     */
+    private String oauthClientAttestation;
+
+
+    /**
+     * The value of the {@code OAuth-Client-Attestation-PoP} HTTP header.
+     *
+     * @since 4.3
+     * @since Authlete 3.0
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/draft-ietf-oauth-attestation-based-client-auth/"
+     *      >OAuth 2.0 Attestation-Based Client Authentication</a>
+     */
+    private String oauthClientAttestationPop;
 
 
     /**
@@ -1048,6 +1092,88 @@ public class TokenRequest implements Serializable
     public TokenRequest setDpopNonceRequired(boolean required)
     {
         this.dpopNonceRequired = required;
+
+        return this;
+    }
+
+
+    /**
+     * Get the value of the {@code OAuth-Client-Attestation} HTTP header.
+     *
+     * @return
+     *         The value of the {@code OAuth-Client-Attestation} HTTP header.
+     *
+     * @since 4.3
+     * @since Authlete 3.0
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/draft-ietf-oauth-attestation-based-client-auth/"
+     *      >OAuth 2.0 Attestation-Based Client Authentication</a>
+     */
+    public String getOauthClientAttestation()
+    {
+        return oauthClientAttestation;
+    }
+
+
+    /**
+     * Set the value of the {@code OAuth-Client-Attestation} HTTP header.
+     *
+     * @param jwt
+     *         The value of the {@code OAuth-Client-Attestation} HTTP header.
+     *
+     * @return
+     *         {@code this} object.
+     *
+     * @since 4.3
+     * @since Authlete 3.0
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/draft-ietf-oauth-attestation-based-client-auth/"
+     *      >OAuth 2.0 Attestation-Based Client Authentication</a>
+     */
+    public TokenRequest setOauthClientAttestation(String jwt)
+    {
+        this.oauthClientAttestation = jwt;
+
+        return this;
+    }
+
+
+    /**
+     * Get the value of the {@code OAuth-Client-Attestation-PoP} HTTP header.
+     *
+     * @return
+     *         The value of the {@code OAuth-Client-Attestation-PoP} HTTP header.
+     *
+     * @since 4.3
+     * @since Authlete 3.0
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/draft-ietf-oauth-attestation-based-client-auth/"
+     *      >OAuth 2.0 Attestation-Based Client Authentication</a>
+     */
+    public String getOauthClientAttestationPop()
+    {
+        return oauthClientAttestationPop;
+    }
+
+
+    /**
+     * Set the value of the {@code OAuth-Client-Attestation-PoP} HTTP header.
+     *
+     * @param jwt
+     *         The value of the {@code OAuth-Client-Attestation-PoP} HTTP header.
+     *
+     * @return
+     *         {@code this} object.
+     *
+     * @since 4.3
+     * @since Authlete 3.0
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/draft-ietf-oauth-attestation-based-client-auth/"
+     *      >OAuth 2.0 Attestation-Based Client Authentication</a>
+     */
+    public TokenRequest setOauthClientAttestationPop(String jwt)
+    {
+        this.oauthClientAttestationPop = jwt;
 
         return this;
     }

--- a/src/main/java/com/authlete/common/types/ClientAssertionType.java
+++ b/src/main/java/com/authlete/common/types/ClientAssertionType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Authlete, Inc.
+ * Copyright (C) 2023-2024 Authlete, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -49,6 +49,19 @@ public enum ClientAssertionType
      * The client assertion type used by the {@code attest_jwt_client_auth}
      * client authentication method.
      * </p>
+     *
+     * <p>
+     * The draft 03 of "OAuth 2.0 Attestation-Based Client Authentication" has
+     * deprecated the usage of the {@code client_assertion} parameter and the
+     * {@code client_assertion_type} parameter, and introduced another different
+     * way to specify a pair of a client attestation and a client attestation PoP.
+     * Consequently, this enum entry is no longer used.
+     * </p>
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/draft-ietf-oauth-attestation-based-client-auth/"
+     *      >OAuth 2.0 Attestation-Based Client Authentication</a>
+     *
+     * @deprecated
      */
     JWT_CLIENT_ATTESTATION((short)2, "urn:ietf:params:oauth:client-assertion-type:jwt-client-attestation"),
     ;

--- a/src/main/java/com/authlete/common/types/ClientAuthMethod.java
+++ b/src/main/java/com/authlete/common/types/ClientAuthMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2023 Authlete, Inc.
+ * Copyright (C) 2014-2024 Authlete, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -152,6 +152,9 @@ public enum ClientAuthMethod
      *
      * @since 3.74
      * @since Authlete 3.0
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/draft-ietf-oauth-attestation-based-client-auth/"
+     *      >OAuth 2.0 Attestation-Based Client Authentication</a>
      */
     ATTEST_JWT_CLIENT_AUTH((short)7, "attest_jwt_client_auth", 0x2),
     ;


### PR DESCRIPTION
Add request parameters to pass the values of the `OAuth-Client-Attestation` and `OAuth-Client-Attestation-PoP` HTTP headers, which are defined in OAuth 2.0 Attestation-Based Client Authentication.

Datatracker: https://datatracker.ietf.org/doc/draft-ietf-oauth-attestation-based-client-auth/