### PR TITLE
[bugfix] ClaimRequirement with `essential` or `purpose` only

### DIFF
--- a/CHANGES.ja.md
+++ b/CHANGES.ja.md
@@ -1,28 +1,37 @@
 変更点
 ======
 
+- `ClaimRequirement` クラス
+    * `isEssential()` メソッドを追加。
+    * `setEssential(boolean)` メソッドを追加。
+    * `getPurpose()` メソッドを追加。
+    * `setPurpose(String)` メソッドを追加。
+    * `value`, `values`, `max_age` 制約のいずれも伴わずに `essential` または
+      `purpose` が指定されるケースをサポートするため `parse(Map)` メソッドの実装を更新。
+
+
 4.8 (2024 年 07 月 01 日)
 -------------------------
 
 - `BackchannelAuthenticationCompleteRequest` クラス
-    * `getAccessTokenDuration()` メソッドを追加
-    * `setAccessTokenDuration(long)` メソッドを追加
-    * `getRefreshTokenDuration()` メソッドを追加
-    * `setRefreshTokenDuration(long)` メソッドを追加
+    * `getAccessTokenDuration()` メソッドを追加。
+    * `setAccessTokenDuration(long)` メソッドを追加。
+    * `getRefreshTokenDuration()` メソッドを追加。
+    * `setRefreshTokenDuration(long)` メソッドを追加。
 
 - `DeviceCompleteRequest` クラス
-    * `getAccessTokenDuration()` メソッドを追加
-    * `setAccessTokenDuration(long)` メソッドを追加
-    * `getRefreshTokenDuration()` メソッドを追加
-    * `setRefreshTokenDuration(long)` メソッドを追加
+    * `getAccessTokenDuration()` メソッドを追加。
+    * `setAccessTokenDuration(long)` メソッドを追加。
+    * `getRefreshTokenDuration()` メソッドを追加。
+    * `setRefreshTokenDuration(long)` メソッドを追加。
 
 - `TokenIssueRequest` クラス
-    * `getRefreshTokenDuration()` メソッドを追加
-    * `setRefreshTokenDuration(long)` メソッドを追加
+    * `getRefreshTokenDuration()` メソッドを追加。
+    * `setRefreshTokenDuration(long)` メソッドを追加。
 
 - `TokenRequest` クラス
-    * `getRefreshTokenDuration()` メソッドを追加
-    * `setRefreshTokenDuration(long)` メソッドを追加
+    * `getRefreshTokenDuration()` メソッドを追加。
+    * `setRefreshTokenDuration(long)` メソッドを追加。
 
 
 4.7 (2024 年 07 月 01 日)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,16 @@
 CHANGES
 =======
 
+- `ClaimRequirement` class
+    * Added `isEssential()` method.
+    * Added `setEssential(boolean)` method.
+    * Added `getPurpose()` method.
+    * Added `setPurpose(String)` method.
+    * Updated the implementation of the `parse(Map)` method to support cases
+      where `essential` or `purpose` is specified without any of `value`,
+      `values` and `max_age` constraints.
+
+
 4.8 (2024-07-01)
 ----------------
 

--- a/src/main/java/com/authlete/common/ida/ClaimRequirementChecker.java
+++ b/src/main/java/com/authlete/common/ida/ClaimRequirementChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Authlete, Inc.
+ * Copyright (C) 2022-2024 Authlete, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -136,6 +136,40 @@ class ClaimRequirementChecker
 
         boolean satisfied = true;
 
+        // NOTE for the "essential" constraint:
+        //
+        // From a filtering point of view, the "essential" constraint is
+        // meaningless because even if "essential":true is specified and the
+        // said claim is unavailable, the authorization server must not treat
+        // the case as an error.
+        //
+        //   OpenID Connect Core 1.0 / 5.5.1. Individual Claims Requests
+        //
+        //     essential
+        //       OPTIONAL. Indicates whether the Claim being requested is an
+        //       Essential Claim. If the value is true, this indicates that the
+        //       Claim is an Essential Claim. For instance, the Claim request:
+        //
+        //         "auth_time": {"essential": true}
+        //
+        //       can be used to specify that it is Essential to return an
+        //       auth_time Claim Value.
+        //
+        //       If the value is false, it indicates that it is a Voluntary
+        //       Claim. The default is false.
+        //
+        //       By requesting Claims as Essential Claims, the RP indicates to
+        //       the End-User that releasing these Claims will ensure a smooth
+        //       authorization for the specific task requested by the End-User.
+        //       Note that even if the Claims are not available because the
+        //       End-User did not authorize their release or they are not
+        //       present, the Authorization Server MUST NOT generate an error
+        //       when Claims are not returned, whether they are Essential or
+        //       Voluntary, unless otherwise specified in the description of
+        //       the specific claim.
+        //
+        // Therefore, we do nothing here for requirement.isEssential().
+
         // If the requirement contains "value".
         if (requirement.getValue() != null)
         {
@@ -157,6 +191,13 @@ class ClaimRequirementChecker
             satisfied &= checkWithMaxAge(
                     value, requirement.getMaxAge(), getCurrentTime());
         }
+
+        // NOTE for the "purpose" property:
+        //
+        // The "purpose" property is not a constraint. It does not affect
+        // the result of this requirement check.
+        //
+        // Therefore, We do nothing here for requirement.getPurpose().
 
         return satisfied;
     }

--- a/src/test/java/com/authlete/common/ida/DatasetExtractorTest.java
+++ b/src/test/java/com/authlete/common/ida/DatasetExtractorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Authlete, Inc.
+ * Copyright (C) 2022-2024 Authlete, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -927,5 +927,210 @@ public class DatasetExtractorTest
         // Check the properties of the element.
         assertEquals("'assurance_type' is wrong.", "evidence_validation", (String)first.get("assurance_type"));
         assertEquals("'assurance_classification' is wrong.", "score_2", (String)first.get("assurance_classification"));
+    }
+
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testEssentialFalse()
+    {
+        Object original = getDataset(EVIDENCE_WITH_ASSURANCE_DETAILS);
+        Map<String, Object> request = fromJson(
+                "{" +
+                  "\"verification\":{" +
+                    "\"trust_framework\":null," +
+                    "\"assurance_process\":{" +
+                      "\"assurance_details\":null" +
+                    "}" +
+                  "}," +
+                  "\"claims\":{" +
+                    "\"given_name\":{" +
+                      "\"essential\":false" +
+                    "}" +
+                  "}" +
+                "}"
+        );
+
+        Map<String, Object> dataset = extract(request, original);
+        assertNotNull("dataset is null.", dataset);
+
+        Map<String, Object> claims = (Map<String, Object>)dataset.get("claims");
+        assertNotNull("'claims' is null.", claims);
+
+        String givenName = (String)claims.get("given_name");
+        assertEquals("'given_name' does not match.", "Sarah", givenName);
+    }
+
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testEssentialTrue()
+    {
+        Object original = getDataset(EVIDENCE_WITH_ASSURANCE_DETAILS);
+        Map<String, Object> request = fromJson(
+                "{" +
+                  "\"verification\":{" +
+                    "\"trust_framework\":null," +
+                    "\"assurance_process\":{" +
+                      "\"assurance_details\":null" +
+                    "}" +
+                  "}," +
+                  "\"claims\":{" +
+                    "\"given_name\":{" +
+                      "\"essential\":true" +
+                    "}" +
+                  "}" +
+                "}"
+        );
+
+        Map<String, Object> dataset = extract(request, original);
+        assertNotNull("dataset is null.", dataset);
+
+        Map<String, Object> claims = (Map<String, Object>)dataset.get("claims");
+        assertNotNull("'claims' is null.", claims);
+
+        String givenName = (String)claims.get("given_name");
+        assertEquals("'given_name' does not match.", "Sarah", givenName);
+    }
+
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testEssentialTrueAndValue()
+    {
+        Object original = getDataset(EVIDENCE_WITH_ASSURANCE_DETAILS);
+        Map<String, Object> request = fromJson(
+                "{" +
+                  "\"verification\":{" +
+                    "\"trust_framework\":null," +
+                    "\"assurance_process\":{" +
+                      "\"assurance_details\":null" +
+                    "}" +
+                  "}," +
+                  "\"claims\":{" +
+                    "\"given_name\":{" +
+                      "\"essential\":true," +
+                      "\"value\":\"Sarah\"" +
+                    "}" +
+                  "}" +
+                "}"
+        );
+
+        Map<String, Object> dataset = extract(request, original);
+        assertNotNull("dataset is null.", dataset);
+
+        Map<String, Object> claims = (Map<String, Object>)dataset.get("claims");
+        assertNotNull("'claims' is null.", claims);
+
+        String givenName = (String)claims.get("given_name");
+        assertEquals("'given_name' does not match.", "Sarah", givenName);
+    }
+
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testEssentialTrueForUnavailableClaim()
+    {
+        String UNAVAILABLE_CLAIM_NAME = "unavailable_claim";
+
+        Object original = getDataset(EVIDENCE_WITH_ASSURANCE_DETAILS);
+        Map<String, Object> request = fromJson(
+                "{" +
+                  "\"verification\":{" +
+                    "\"trust_framework\":null," +
+                    "\"assurance_process\":{" +
+                      "\"assurance_details\":null" +
+                    "}" +
+                  "}," +
+                  "\"claims\":{" +
+                    "\"given_name\":null," +
+                    "\"" + UNAVAILABLE_CLAIM_NAME + "\":{" +
+                      "\"essential\":true" +
+                    "}" +
+                  "}" +
+                "}"
+        );
+
+        // Even if "essential":true is specified and the said claim is unavailable,
+        // the authorization server should not treat the case as an error. Refer to
+        // the description about "essential" written in OIDC Core 1.0, 5.5.1.
+        // Individual Claims Requests.
+
+        Map<String, Object> dataset = extract(request, original);
+        assertNotNull("dataset is null.", dataset);
+
+        Map<String, Object> claims = (Map<String, Object>)dataset.get("claims");
+        assertNotNull("'claims' is null.", claims);
+
+        String givenName = (String)claims.get("given_name");
+        assertEquals("'given_name' does not match.", "Sarah", givenName);
+
+        boolean available = claims.containsKey(UNAVAILABLE_CLAIM_NAME);
+        assertFalse("'" + UNAVAILABLE_CLAIM_NAME + "' is available.", available);
+    }
+
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testPurpose()
+    {
+        Object original = getDataset(EVIDENCE_WITH_ASSURANCE_DETAILS);
+        Map<String, Object> request = fromJson(
+                "{" +
+                  "\"verification\":{" +
+                    "\"trust_framework\":null," +
+                    "\"assurance_process\":{" +
+                      "\"assurance_details\":null" +
+                    "}" +
+                  "}," +
+                  "\"claims\":{" +
+                    "\"given_name\":{" +
+                      "\"purpose\":\"the purpose for requesting given_name\"" +
+                    "}" +
+                  "}" +
+                "}"
+        );
+
+        Map<String, Object> dataset = extract(request, original);
+        assertNotNull("dataset is null.", dataset);
+
+        Map<String, Object> claims = (Map<String, Object>)dataset.get("claims");
+        assertNotNull("'claims' is null.", claims);
+
+        String givenName = (String)claims.get("given_name");
+        assertEquals("'given_name' does not match.", "Sarah", givenName);
+    }
+
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testPurposeAndValue()
+    {
+        Object original = getDataset(EVIDENCE_WITH_ASSURANCE_DETAILS);
+        Map<String, Object> request = fromJson(
+                "{" +
+                  "\"verification\":{" +
+                    "\"trust_framework\":null," +
+                    "\"assurance_process\":{" +
+                      "\"assurance_details\":null" +
+                    "}" +
+                  "}," +
+                  "\"claims\":{" +
+                    "\"given_name\":{" +
+                      "\"purpose\":\"the purpose for requesting given_name\"," +
+                      "\"value\":\"Sarah\"" +
+                    "}" +
+                  "}" +
+                "}"
+        );
+
+        Map<String, Object> dataset = extract(request, original);
+        assertNotNull("dataset is null.", dataset);
+
+        Map<String, Object> claims = (Map<String, Object>)dataset.get("claims");
+        assertNotNull("'claims' is null.", claims);
+
+        String givenName = (String)claims.get("given_name");
+        assertEquals("'given_name' does not match.", "Sarah", givenName);
     }
 }


### PR DESCRIPTION
Update the implementation of the `ClaimRequirement.parse(Map)` method to support cases where `essential` or `purpose` is specified without any of `value`, `values` and `max_age` constraints.