### PR TITLE
[update] Request options

### DIFF
--- a/src/main/java/com/authlete/common/api/AuthleteApi.java
+++ b/src/main/java/com/authlete/common/api/AuthleteApi.java
@@ -135,7 +135,27 @@ public interface AuthleteApi
      * @return
      *         Response from the API.
      */
-    AuthorizationResponse authorization(AuthorizationRequest request) throws AuthleteApiException;
+    default AuthorizationResponse authorization(AuthorizationRequest request) throws AuthleteApiException
+    {
+        return authorization(request, null);
+    }
+
+
+    /**
+     * Call Authlete's {@code /auth/authorization} API.
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     */
+    AuthorizationResponse authorization(AuthorizationRequest request, Options options) throws AuthleteApiException;
 
 
     /**
@@ -147,7 +167,27 @@ public interface AuthleteApi
      * @return
      *         Response from the API.
      */
-    AuthorizationFailResponse authorizationFail(AuthorizationFailRequest request) throws AuthleteApiException;
+    default AuthorizationFailResponse authorizationFail(AuthorizationFailRequest request) throws AuthleteApiException
+    {
+        return authorizationFail(request, null);
+    }
+
+
+    /**
+     * Call Authlete's {@code /auth/authorization/fail} API.
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     */
+    AuthorizationFailResponse authorizationFail(AuthorizationFailRequest request, Options options) throws AuthleteApiException;
 
 
     /**
@@ -159,7 +199,27 @@ public interface AuthleteApi
      * @return
      *         Response from the API.
      */
-    AuthorizationIssueResponse authorizationIssue(AuthorizationIssueRequest request) throws AuthleteApiException;
+    default AuthorizationIssueResponse authorizationIssue(AuthorizationIssueRequest request) throws AuthleteApiException
+    {
+        return authorizationIssue(request, null);
+    }
+
+
+    /**
+     * Call Authlete's {@code /auth/authorization/issue} API.
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     */
+    AuthorizationIssueResponse authorizationIssue(AuthorizationIssueRequest request, Options options) throws AuthleteApiException;
 
 
     /**
@@ -171,7 +231,27 @@ public interface AuthleteApi
      * @return
      *         Response from the API.
      */
-    TokenResponse token(TokenRequest request) throws AuthleteApiException;
+    default TokenResponse token(TokenRequest request) throws AuthleteApiException
+    {
+        return token(request, null);
+    }
+
+
+    /**
+     * Call Authlete's {@code /auth/token} API.
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     */
+    TokenResponse token(TokenRequest request, Options options) throws AuthleteApiException;
 
 
     /**
@@ -185,7 +265,27 @@ public interface AuthleteApi
      *
      * @since 1.13
      */
-    TokenCreateResponse tokenCreate(TokenCreateRequest request) throws AuthleteApiException;
+    default TokenCreateResponse tokenCreate(TokenCreateRequest request) throws AuthleteApiException
+    {
+        return tokenCreate(request, null);
+    }
+
+
+    /**
+     * Call Authlete's {@code /auth/token/create} API.
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     */
+    TokenCreateResponse tokenCreate(TokenCreateRequest request, Options options) throws AuthleteApiException;
 
 
     /**
@@ -196,7 +296,27 @@ public interface AuthleteApi
      *
      * @since 2.81
      */
-    void tokenDelete(String token) throws AuthleteApiException;
+    default void tokenDelete(String token) throws AuthleteApiException
+    {
+        tokenDelete(token, null);
+    }
+
+
+    /**
+     * Call Authlete's {@code /auth/token/delete} API.
+     *
+     * @param token
+     *         An access token or its hash value.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     */
+    void tokenDelete(String token, Options options) throws AuthleteApiException;
 
 
     /**
@@ -208,7 +328,27 @@ public interface AuthleteApi
      * @return
      *         Response from the API.
      */
-    TokenFailResponse tokenFail(TokenFailRequest request) throws AuthleteApiException;
+    default TokenFailResponse tokenFail(TokenFailRequest request) throws AuthleteApiException
+    {
+        return tokenFail(request, null);
+    }
+
+
+    /**
+     * Call Authlete's {@code /auth/token/fail} API.
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     */
+    TokenFailResponse tokenFail(TokenFailRequest request, Options options) throws AuthleteApiException;
 
 
     /**
@@ -220,7 +360,27 @@ public interface AuthleteApi
      * @return
      *         Response from the API.
      */
-    TokenIssueResponse tokenIssue(TokenIssueRequest request) throws AuthleteApiException;
+    default TokenIssueResponse tokenIssue(TokenIssueRequest request) throws AuthleteApiException
+    {
+        return tokenIssue(request, null);
+    }
+
+
+    /**
+     * Call Authlete's {@code /auth/token/issue} API.
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     */
+    TokenIssueResponse tokenIssue(TokenIssueRequest request, Options options) throws AuthleteApiException;
 
 
     /**
@@ -235,7 +395,27 @@ public interface AuthleteApi
      * @since 3.26
      * @since Authlete 2.2.29
      */
-    TokenRevokeResponse tokenRevoke(TokenRevokeRequest request) throws AuthleteApiException;
+    default TokenRevokeResponse tokenRevoke(TokenRevokeRequest request) throws AuthleteApiException
+    {
+        return tokenRevoke(request, null);
+    }
+
+
+    /**
+     * Call Authlete's {@code /auth/token/revoke} API.
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     */
+    TokenRevokeResponse tokenRevoke(TokenRevokeRequest request, Options options) throws AuthleteApiException;
 
 
     /**
@@ -249,7 +429,27 @@ public interface AuthleteApi
      *
      * @since 1.34
      */
-    TokenUpdateResponse tokenUpdate(TokenUpdateRequest request) throws AuthleteApiException;
+    default TokenUpdateResponse tokenUpdate(TokenUpdateRequest request) throws AuthleteApiException
+    {
+        return tokenUpdate(request, null);
+    }
+
+
+    /**
+     * Call Authlete's {@code /auth/token/update} API.
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     */
+    TokenUpdateResponse tokenUpdate(TokenUpdateRequest request, Options options) throws AuthleteApiException;
 
 
     /**
@@ -268,7 +468,32 @@ public interface AuthleteApi
      *
      * @since 2.29
      */
-    TokenListResponse getTokenList() throws AuthleteApiException;
+    default TokenListResponse getTokenList() throws AuthleteApiException
+    {
+        return getTokenList((Options)null);
+    }
+
+
+    /**
+     * Get the list of access tokens that are associated with the
+     * service
+     * (= call Authlete's {@code /auth/token/get/list} API).
+     *
+     * <p>
+     * This method uses the default range to limit the result set
+     * of the query. Use {@link #getTokenList(int, int, TokenStatus)}
+     * to specify the range explicitly.
+     * </p>
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         The list of access tokens.
+     *
+     * @since 4.15
+     */
+    TokenListResponse getTokenList(Options options) throws AuthleteApiException;
 
 
     /**
@@ -290,7 +515,35 @@ public interface AuthleteApi
      *
      * @since 3.97
      */
-    TokenListResponse getTokenList(TokenStatus tokenStatus) throws AuthleteApiException;
+    default TokenListResponse getTokenList(TokenStatus tokenStatus) throws AuthleteApiException
+    {
+        return getTokenList(tokenStatus, null);
+    }
+
+
+    /**
+     * Get the list of access tokens that are associated with the
+     * service
+     * (= call Authlete's {@code /auth/token/get/list} API).
+     *
+     * <p>
+     * This method uses the default range to limit the result set
+     * of the query. Use {@link #getTokenList(int, int, TokenStatus)}
+     * to specify the range explicitly.
+     * </p>
+     *
+     * @param tokenStatus
+     *         The status of the targeted access tokens, or {@code null}.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         The list of access tokens.
+     *
+     * @since 4.15
+     */
+    TokenListResponse getTokenList(TokenStatus tokenStatus, Options options) throws AuthleteApiException;
 
 
     /**
@@ -340,8 +593,65 @@ public interface AuthleteApi
      *
      * @since 2.29
      */
+    default TokenListResponse getTokenList(
+            String clientIdentifier, String subject) throws AuthleteApiException
+    {
+        return getTokenList(clientIdentifier, subject, (Options)null);
+    }
+
+
+    /**
+     * Get the list of access tokens
+     * (= call Authlete's {@code /auth/token/get/list} API with
+     * {@code clientIdentifier} and {@code subject}).
+     *
+     * <p>
+     * When both {@code clientIdentifier} and {@code subject} are
+     * {@code null}, the list of access tokens that are associated
+     * with the service is returned.
+     * </p>
+     *
+     * <p>
+     * When {@code clientIdentifier} is {@code null} but the {@code subject}
+     * is not {@code null}, the list of access tokens that are associated
+     * with the subject is returned.
+     * </p>
+     *
+     * <p>
+     * When {@code clientIdentifier} is not {@code null} but the
+     * {@code subject} is {@code null}, the list of access tokens
+     * that are associated with the client application is returned.
+     * </p>
+     *
+     * <p>
+     * When neither {@code clientIdentifier} nor {@code subject} is
+     * {@code null}, the list of access tokens that are associated
+     * with the client application and the subject is returned.
+     * </p>
+     *
+     * <p>
+     * This method uses the default range to limit the result set
+     * of the query. Use {@link #getTokenList(String, String, int, int, TokenStatus)}
+     * to specify the range explicitly.
+     * </p>
+     *
+     * @param clientIdentifier
+     *         The identifier of the client (client ID or client ID alias)
+     *         associated with the targeted access tokens, or {@code null}.
+     *
+     * @param subject
+     *         The subject of the targeted access tokens, or {@code null}.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         The list of access tokens.
+     *
+     * @since 4.15
+     */
     TokenListResponse getTokenList(
-            String clientIdentifier, String subject) throws AuthleteApiException;
+            String clientIdentifier, String subject, Options options) throws AuthleteApiException;
 
 
     /**
@@ -394,8 +704,69 @@ public interface AuthleteApi
      *
      * @since 3.97
      */
-    TokenListResponse getTokenList(
+    default TokenListResponse getTokenList(
             String clientIdentifier, String subject, TokenStatus tokenStatus)
+                    throws AuthleteApiException
+    {
+        return getTokenList(clientIdentifier, subject, tokenStatus, null);
+    }
+
+
+    /**
+     * Get the list of access tokens
+     * (= call Authlete's {@code /auth/token/get/list} API with
+     * {@code clientIdentifier} and {@code subject}).
+     *
+     * <p>
+     * When both {@code clientIdentifier} and {@code subject} are
+     * {@code null}, the list of access tokens that are associated
+     * with the service is returned.
+     * </p>
+     *
+     * <p>
+     * When {@code clientIdentifier} is {@code null} but the {@code subject}
+     * is not {@code null}, the list of access tokens that are associated
+     * with the subject is returned.
+     * </p>
+     *
+     * <p>
+     * When {@code clientIdentifier} is not {@code null} but the
+     * {@code subject} is {@code null}, the list of access tokens
+     * that are associated with the client application is returned.
+     * </p>
+     *
+     * <p>
+     * When neither {@code clientIdentifier} nor {@code subject} is
+     * {@code null}, the list of access tokens that are associated
+     * with the client application and the subject is returned.
+     * </p>
+     *
+     * <p>
+     * This method uses the default range to limit the result set
+     * of the query. Use {@link #getTokenList(String, String, int, int, TokenStatus)}
+     * to specify the range explicitly.
+     * </p>
+     *
+     * @param clientIdentifier
+     *         The identifier of the client (client ID or client ID alias)
+     *         associated with the targeted access tokens, or {@code null}.
+     *
+     * @param subject
+     *         The subject of the targeted access tokens, or {@code null}.
+     *
+     * @param tokenStatus
+     *         The status of the targeted access tokens, or {@code null}.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         The list of access tokens.
+     *
+     * @since 4.15
+     */
+    TokenListResponse getTokenList(
+            String clientIdentifier, String subject, TokenStatus tokenStatus, Options options)
                     throws AuthleteApiException;
 
 
@@ -444,7 +815,61 @@ public interface AuthleteApi
      *
      * @since 2.29
      */
-    TokenListResponse getTokenList(int start, int end) throws AuthleteApiException;
+    default TokenListResponse getTokenList(int start, int end) throws AuthleteApiException
+    {
+        return getTokenList(start, end, (Options)null);
+    }
+
+
+    /**
+     * Get the list of access tokens that are associated with the
+     * service
+     * (= call Authlete's {@code /auth/token/get/list} API
+     * with {@code start} and {@code end} parameters).
+     *
+     * <p>
+     * The pair of {@code start} and {@code end} parameters denotes
+     * the range of the result set of the query. For example, if
+     * {@code start} is 5 and {@code end} is 7, the pair makes a
+     * range from 5 (inclusive) to 7 (exclusive) and the response
+     * will contain (at most) 2 pieces of access token information,
+     * i.e., information about the 6th and the 7th access tokens (the
+     * index starts from 0).
+     * </p>
+     *
+     * <p>
+     * If {@code end - start} is equal to or less than 0, {@link
+     * TokenListResponse#getAccessTokens() getAccessTokens()} method
+     * of the response returns {@code null}. But even in such a case,
+     * {@link TokenListResponse#getTotalCount() getTotalCount()}
+     * method returns the total count. In other words, if you want
+     * to get just the total count, you can write the code as
+     * shown below.
+     * </p>
+     *
+     * <pre>
+     * int totalCount = api.{@link #getTokenList(int, int)
+     * getTokenList(0, 0)}.{@link TokenListResponse#getTotalCount()
+     * getTotalCount()};
+     * </pre>
+     *
+     * @param start
+     *         The start index (inclusive) of the result set of the query.
+     *         Must not be negative.
+     *
+     * @param end
+     *         The end index (exclusive) of the result set of the query.
+     *         Must not be negative.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         The list of access tokens.
+     *
+     * @since 4.15
+     */
+    TokenListResponse getTokenList(int start, int end, Options options) throws AuthleteApiException;
 
 
     /**
@@ -495,8 +920,66 @@ public interface AuthleteApi
      *
      * @since 3.97
      */
+    default TokenListResponse getTokenList(
+            int start, int end, TokenStatus tokenStatus) throws AuthleteApiException
+    {
+        return getTokenList(start, end, tokenStatus, null);
+    }
+
+
+    /**
+     * Get the list of access tokens that are associated with the
+     * service
+     * (= call Authlete's {@code /auth/token/get/list} API
+     * with {@code start} and {@code end} parameters).
+     *
+     * <p>
+     * The pair of {@code start} and {@code end} parameters denotes
+     * the range of the result set of the query. For example, if
+     * {@code start} is 5 and {@code end} is 7, the pair makes a
+     * range from 5 (inclusive) to 7 (exclusive) and the response
+     * will contain (at most) 2 pieces of access token information,
+     * i.e., information about the 6th and the 7th access tokens (the
+     * index starts from 0).
+     * </p>
+     *
+     * <p>
+     * If {@code end - start} is equal to or less than 0, {@link
+     * TokenListResponse#getAccessTokens() getAccessTokens()} method
+     * of the response returns {@code null}. But even in such a case,
+     * {@link TokenListResponse#getTotalCount() getTotalCount()}
+     * method returns the total count. In other words, if you want
+     * to get just the total count, you can write the code as
+     * shown below.
+     * </p>
+     *
+     * <pre>
+     * int totalCount = api.{@link #getTokenList(int, int, TokenStatus)
+     * getTokenList(0, 0, TokenStatus.ALL)}.{@link TokenListResponse#getTotalCount()
+     * getTotalCount()};
+     * </pre>
+     *
+     * @param start
+     *         The start index (inclusive) of the result set of the query.
+     *         Must not be negative.
+     *
+     * @param end
+     *         The end index (exclusive) of the result set of the query.
+     *         Must not be negative.
+     *
+     * @param tokenStatus
+     *         The status of the targeted access tokens, or {@code null}.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         The list of access tokens.
+     *
+     * @since 4.15
+     */
     TokenListResponse getTokenList(
-            int start, int end, TokenStatus tokenStatus) throws AuthleteApiException;
+            int start, int end, TokenStatus tokenStatus, Options options) throws AuthleteApiException;
 
 
     /**
@@ -574,8 +1057,93 @@ public interface AuthleteApi
      *
      * @since 2.29
      */
+    default TokenListResponse getTokenList(String clientIdentifier, String subject,
+            int start, int end) throws AuthleteApiException
+    {
+        return getTokenList(clientIdentifier, subject, start, end, (Options)null);
+    }
+
+
+    /**
+     * Get the list of access tokens
+     * (= call Authlete's {@code /auth/token/get/list} API with {@code clientIdentifier},
+     * {@code subject}, {@code start} and {@code end} parameters).
+     *
+     * <p>
+     * When both {@code clientIdentifier} and {@code subject} are
+     * {@code null}, the list of access tokens that are associated
+     * with the service is returned.
+     * </p>
+     *
+     * <p>
+     * When {@code clientIdentifier} is {@code null} but the {@code subject}
+     * is not {@code null}, the list of access tokens that are associated
+     * with the subject is returned.
+     * </p>
+     *
+     * <p>
+     * When {@code clientIdentifier} is not {@code null} but the
+     * {@code subject} is {@code null}, the list of access tokens
+     * that are associated with the client application is returned.
+     * </p>
+     *
+     * <p>
+     * When neither {@code clientIdentifier} nor {@code subject} is
+     * {@code null}, the list of access tokens that are associated
+     * with the client application and the subject is returned.
+     * </p>
+     *
+     * <p>
+     * The pair of {@code start} and {@code end} parameters denotes
+     * the range of the result set of the query. For example, if
+     * {@code start} is 5 and {@code end} is 7, the pair makes a
+     * range from 5 (inclusive) to 7 (exclusive) and the response
+     * will contain (at most) 2 pieces of access token information,
+     * i.e., information about the 6th and the 7th access tokens (the
+     * index starts from 0).
+     * </p>
+     *
+     * <p>
+     * If {@code end - start} is equal to or less than 0, {@link
+     * TokenListResponse#getAccessTokens() getAccessTokens()} method
+     * of the response returns {@code null}. But even in such a case,
+     * {@link TokenListResponse#getTotalCount() getTotalCount()}
+     * method returns the total count. In other words, if you want
+     * to get just the total count, you can write the code as
+     * shown below.
+     * </p>
+     *
+     * <pre>
+     * int totalCount = api.{@link #getTokenList(String, String, int, int)
+     * getTokenList(clientIdentifier, subject, 0, 0)}.{@link TokenListResponse#getTotalCount()
+     * getTotalCount()};
+     * </pre>
+     *
+     * @param clientIdentifier
+     *         The identifier of the client (client ID or client ID alias)
+     *         associated with the targeted access tokens, or {@code null}.
+     *
+     * @param subject
+     *         The subject of the targeted access tokens, or {@code null}.
+     *
+     * @param start
+     *         The start index (inclusive) of the result set of the query.
+     *         Must not be negative.
+     *
+     * @param end
+     *         The end index (exclusive) of the result set of the query.
+     *         Must not be negative.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         The list of access tokens.
+     *
+     * @since 4.15
+     */
     TokenListResponse getTokenList(String clientIdentifier, String subject,
-            int start, int end) throws AuthleteApiException;
+            int start, int end, Options options) throws AuthleteApiException;
 
 
     /**
@@ -656,8 +1224,97 @@ public interface AuthleteApi
      *
      * @since 3.97
      */
-    TokenListResponse getTokenList(
+    default TokenListResponse getTokenList(
             String clientIdentifier, String subject, int start, int end, TokenStatus tokenStatus)
+                    throws AuthleteApiException
+    {
+        return getTokenList(clientIdentifier, subject, start, end, tokenStatus, null);
+    }
+
+
+    /**
+     * Get the list of access tokens
+     * (= call Authlete's {@code /auth/token/get/list} API with {@code clientIdentifier},
+     * {@code subject}, {@code start} and {@code end} parameters).
+     *
+     * <p>
+     * When both {@code clientIdentifier} and {@code subject} are
+     * {@code null}, the list of access tokens that are associated
+     * with the service is returned.
+     * </p>
+     *
+     * <p>
+     * When {@code clientIdentifier} is {@code null} but the {@code subject}
+     * is not {@code null}, the list of access tokens that are associated
+     * with the subject is returned.
+     * </p>
+     *
+     * <p>
+     * When {@code clientIdentifier} is not {@code null} but the
+     * {@code subject} is {@code null}, the list of access tokens
+     * that are associated with the client application is returned.
+     * </p>
+     *
+     * <p>
+     * When neither {@code clientIdentifier} nor {@code subject} is
+     * {@code null}, the list of access tokens that are associated
+     * with the client application and the subject is returned.
+     * </p>
+     *
+     * <p>
+     * The pair of {@code start} and {@code end} parameters denotes
+     * the range of the result set of the query. For example, if
+     * {@code start} is 5 and {@code end} is 7, the pair makes a
+     * range from 5 (inclusive) to 7 (exclusive) and the response
+     * will contain (at most) 2 pieces of access token information,
+     * i.e., information about the 6th and the 7th access tokens (the
+     * index starts from 0).
+     * </p>
+     *
+     * <p>
+     * If {@code end - start} is equal to or less than 0, {@link
+     * TokenListResponse#getAccessTokens() getAccessTokens()} method
+     * of the response returns {@code null}. But even in such a case,
+     * {@link TokenListResponse#getTotalCount() getTotalCount()}
+     * method returns the total count. In other words, if you want
+     * to get just the total count, you can write the code as
+     * shown below.
+     * </p>
+     *
+     * <pre>
+     * int totalCount = api.{@link #getTokenList(String, String, int, int, TokenStatus)
+     * getTokenList(clientIdentifier, subject, 0, 0, TokenStatus.ALL)}.{@link
+     * TokenListResponse#getTotalCount() getTotalCount()};
+     * </pre>
+     *
+     * @param clientIdentifier
+     *         The identifier of the client (client ID or client ID alias)
+     *         associated with the targeted access tokens, or {@code null}.
+     *
+     * @param subject
+     *         The subject of the targeted access tokens, or {@code null}.
+     *
+     * @param start
+     *         The start index (inclusive) of the result set of the query.
+     *         Must not be negative.
+     *
+     * @param end
+     *         The end index (exclusive) of the result set of the query.
+     *         Must not be negative.
+     *
+     * @param tokenStatus
+     *         The status of the targeted access tokens, or {@code null}.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         The list of access tokens.
+     *
+     * @since 4.15
+     */
+    TokenListResponse getTokenList(
+            String clientIdentifier, String subject, int start, int end, TokenStatus tokenStatus, Options options)
                     throws AuthleteApiException;
 
 
@@ -672,7 +1329,27 @@ public interface AuthleteApi
      *
      * @since 1.16
      */
-    RevocationResponse revocation(RevocationRequest request) throws AuthleteApiException;
+    default RevocationResponse revocation(RevocationRequest request) throws AuthleteApiException
+    {
+        return revocation(request, null);
+    }
+
+
+    /**
+     * Call Authlete's {@code /auth/revocation} API.
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     */
+    RevocationResponse revocation(RevocationRequest request, Options options) throws AuthleteApiException;
 
 
     /**
@@ -684,7 +1361,27 @@ public interface AuthleteApi
      * @return
      *         Response from the API.
      */
-    UserInfoResponse userinfo(UserInfoRequest request) throws AuthleteApiException;
+    default UserInfoResponse userinfo(UserInfoRequest request) throws AuthleteApiException
+    {
+        return userinfo(request, null);
+    }
+
+
+    /**
+     * Call Authlete's {@code /auth/userinfo} API.
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     */
+    UserInfoResponse userinfo(UserInfoRequest request, Options options) throws AuthleteApiException;
 
 
     /**
@@ -696,7 +1393,27 @@ public interface AuthleteApi
      * @return
      *         Response from the API.
      */
-    UserInfoIssueResponse userinfoIssue(UserInfoIssueRequest request) throws AuthleteApiException;
+    default UserInfoIssueResponse userinfoIssue(UserInfoIssueRequest request) throws AuthleteApiException
+    {
+        return userinfoIssue(request, null);
+    }
+
+
+    /**
+     * Call Authlete's {@code /auth/userinfo/issue} API.
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     */
+    UserInfoIssueResponse userinfoIssue(UserInfoIssueRequest request, Options options) throws AuthleteApiException;
 
 
     /**
@@ -708,7 +1425,27 @@ public interface AuthleteApi
      * @return
      *         Response from the API.
      */
-    IntrospectionResponse introspection(IntrospectionRequest request) throws AuthleteApiException;
+    default IntrospectionResponse introspection(IntrospectionRequest request) throws AuthleteApiException
+    {
+        return introspection(request, null);
+    }
+
+
+    /**
+     * Call Authlete's {@code /auth/introspection} API.
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     */
+    IntrospectionResponse introspection(IntrospectionRequest request, Options options) throws AuthleteApiException;
 
 
     /**
@@ -722,8 +1459,29 @@ public interface AuthleteApi
      *
      * @since 2.7
      */
+    default StandardIntrospectionResponse standardIntrospection(
+            StandardIntrospectionRequest request) throws AuthleteApiException
+    {
+        return standardIntrospection(request, null);
+    }
+
+
+    /**
+     * Call Authlete's {@code /auth/introspection/standard} API.
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     */
     StandardIntrospectionResponse standardIntrospection(
-            StandardIntrospectionRequest request) throws AuthleteApiException;
+            StandardIntrospectionRequest request, Options options) throws AuthleteApiException;
 
 
     /**
@@ -735,7 +1493,27 @@ public interface AuthleteApi
      * @return
      *         Information about a newly created service.
      */
-    Service createService(Service service) throws AuthleteApiException;
+    default Service createService(Service service) throws AuthleteApiException
+    {
+        return createService(service, null);
+    }
+
+
+    /**
+     * Create a service (= call Authlete's {@code /service/create} API).
+     *
+     * @param service
+     *         Information about a service to create.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     */
+    Service createService(Service service, Options options) throws AuthleteApiException;
 
 
     /**
@@ -751,7 +1529,27 @@ public interface AuthleteApi
      * @param apiKey
      *         The API key of the service.
      */
-    void deleteService(long apiKey) throws AuthleteApiException;
+    default void deleteService(long apiKey) throws AuthleteApiException
+    {
+        deleteService(apiKey, null);
+    }
+
+
+    /**
+     * Delete a service (= call Authlete's <code>/service/delete/{apiKey}</code> API).
+     *
+     * @param apiKey
+     *         The API key of the service.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     */
+    void deleteService(long apiKey, Options options) throws AuthleteApiException;
 
 
     /**
@@ -763,7 +1561,27 @@ public interface AuthleteApi
      * @return
      *         Information about the service.
      */
-    Service getService(long apiKey) throws AuthleteApiException;
+    default Service getService(long apiKey) throws AuthleteApiException
+    {
+        return getService(apiKey, null);
+    }
+
+
+    /**
+     * Get a service (= call Authlete's <code>/service/get/{apiKey}</code> API).
+     *
+     * @param apiKey
+     *         The API key of the service.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Information about the service.
+     *
+     * @since 4.15
+     */
+    Service getService(long apiKey, Options options) throws AuthleteApiException;
 
 
     /**
@@ -779,7 +1597,31 @@ public interface AuthleteApi
      * @return
      *         The list of services.
      */
-    ServiceListResponse getServiceList() throws AuthleteApiException;
+    default ServiceListResponse getServiceList() throws AuthleteApiException
+    {
+        return getServiceList(null);
+    }
+
+
+    /**
+     * Get the list of services that belong to the service owner
+     * (= call Authlete's {@code /service/get/list} API).
+     *
+     * <p>
+     * This method uses the default range to limit the result set
+     * of the query. Use {@link #getServiceList(int, int)} to specify
+     * the range explicitly.
+     * </p>
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         The list of services.
+     *
+     * @since 4.15
+     */
+    ServiceListResponse getServiceList(Options options) throws AuthleteApiException;
 
 
     /**
@@ -824,7 +1666,60 @@ public interface AuthleteApi
      * @return
      *         The list of services.
      */
-    ServiceListResponse getServiceList(int start, int end) throws AuthleteApiException;
+    default ServiceListResponse getServiceList(int start, int end) throws AuthleteApiException
+    {
+        return getServiceList(start, end, null);
+    }
+
+
+    /**
+     * Get the list of services that belong to the service owner
+     * (= call Authlete's {@code /service/get/list} API with {@code
+     * start} and {@code end} parameters).
+     *
+     * <p>
+     * The pair of {@code start} and {@code end} parameters denotes
+     * the range of the result set of the query. For example, if
+     * {@code start} is 5 and {@code end} is 7, the pair makes a
+     * range from 5 (inclusive) to 7 (exclusive) and the response
+     * will contain (at most) 2 pieces of service information, i.e.,
+     * information about the 6th and the 7th services (the index
+     * starts from 0).
+     * </p>
+     *
+     * <p>
+     * If {@code end - start} is equal to or less than 0, {@link
+     * ServiceListResponse#getServices() getServices()} method of
+     * the response returns {@code null}. But even in such a case,
+     * {@link ServiceListResponse#getTotalCount() getTotalCount()}
+     * method returns the total count. In other words, if you want
+     * to get just the total count, you can write the code as
+     * shown below.
+     * </p>
+     *
+     * <pre>
+     * int totalCount = api.{@link #getServiceList(int, int)
+     * getServiceList(0, 0)}.{@link ServiceListResponse#getTotalCount()
+     * getTotalCount()};
+     * </pre>
+     *
+     * @param start
+     *         The start index (inclusive) of the result set of the query.
+     *         Must not be negative.
+     *
+     * @param end
+     *         The end index (exclusive) of the result set of the query.
+     *         Must not be negative.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         The list of services.
+     *
+     * @since 4.15
+     */
+    ServiceListResponse getServiceList(int start, int end, Options options) throws AuthleteApiException;
 
 
     /**
@@ -840,8 +1735,35 @@ public interface AuthleteApi
      *
      * @return
      *         Information about the updated service.
+     *
+     * @since 4.15
      */
-    Service updateService(Service service) throws AuthleteApiException;
+    default Service updateService(Service service) throws AuthleteApiException
+    {
+        return updateService(service, null);
+    }
+
+
+    /**
+     * Update a service (= call Authlete's <code>/service/update/{apiKey}</code> API).
+     *
+     * <p>
+     * {@code service.}{@link Service#getApiKey() getApiKey()} must
+     * return the correct API key of the service.
+     * </p>
+     *
+     * @param service
+     *         Information about a service to update.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Information about the updated service.
+     *
+     * @since 4.15
+     */
+    Service updateService(Service service, Options options) throws AuthleteApiException;
 
 
     /**
@@ -861,7 +1783,33 @@ public interface AuthleteApi
      *
      * @since 1.13
      */
-    String getServiceJwks() throws AuthleteApiException;
+    default String getServiceJwks() throws AuthleteApiException
+    {
+        return getServiceJwks(null);
+    }
+
+
+    /**
+     * Get the JWK Set of a service.
+     *
+     * <p>
+     * This method is an alias of {@link #getServiceJwks(boolean, boolean)
+     * getServiceJwks}{@code (true, false)}.
+     * </p>
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         JSON representation of the JWK Set of the service.
+     *         {@code null} is returned when the service has registered
+     *         neither content or URI of its JWK Set.
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7517">RFC 7517: JSON Web Key (JWK)</a>
+     *
+     * @since 4.15
+     */
+    String getServiceJwks(Options options) throws AuthleteApiException;
 
 
     /**
@@ -951,7 +1899,103 @@ public interface AuthleteApi
      *
      * @since 1.28
      */
-    String getServiceJwks(boolean pretty, boolean includePrivateKeys) throws AuthleteApiException;
+    default String getServiceJwks(boolean pretty, boolean includePrivateKeys) throws AuthleteApiException
+    {
+        return getServiceJwks(pretty, includePrivateKeys, null);
+    }
+
+
+    /**
+     * Get the JWK Set of a service.
+     *
+     * <p>
+     * You can register either or both (1) the content of a JWK set and
+     * (2) the URI of a JWK set. The table below describes how registration
+     * combinations affect the response from this method. For example, the
+     * table indicates that the content of the JWK Set is returned with a
+     * status code 200 if both (content and URI) are registered.
+     * </p>
+     *
+     * <blockquote>
+     * <table border="1" cellpadding="5" style="border-collapse: collapse;">
+     *   <thread>
+     *     <tr>
+     *       <th colspan="2">Service JWK Set</th>
+     *       <th colspan="3">Response</th>
+     *     </tr>
+     *     <tr>
+     *       <th>Content</th>
+     *       <th>URI</th>
+     *       <th>Status Code</th>
+     *       <th>Return Value</th>
+     *       <th>Exception</th>
+     *     </tr>
+     *   </thead>
+     *   <tbody>
+     *     <tr>
+     *       <td>Registered</td>
+     *       <td>Registered</td>
+     *       <td>200 OK</td>
+     *       <td>JWK Set</td>
+     *       <td>Not Raised</td>
+     *     </tr>
+     *     <tr>
+     *       <td>Registered</td>
+     *       <td>Not Registered</td>
+     *       <td>200 OK</td>
+     *       <td>JWK Set</td>
+     *       <td>Not Raised</td>
+     *     </tr>
+     *     <tr>
+     *       <td rowspan="2">Not Registered</td>
+     *       <td rowspan="2">Registered</td>
+     *       <td>204 No Content</td>
+     *       <td>{@code null}</td>
+     *       <td>Not Raised</td>
+     *     </tr>
+     *     <tr>
+     *       <td>302 Found <sup>*</sup></td>
+     *       <td>&nbsp;</td>
+     *       <td>Raised</td>
+     *     </tr>
+     *     <tr>
+     *       <td>Not Registered</td>
+     *       <td>Not Registered</td>
+     *       <td>204 No Content</td>
+     *       <td>{@code null}</td>
+     *       <td>Not Raised</td>
+     *     </tr>
+     *   </tbody>
+     * </table>
+     * </blockquote>
+     *
+     * <p>
+     * 302 Found is returned when the request URI and the registered JWK Set URI
+     * are different. In this case, {@code Location} header contains the registered
+     * JWK Set URI. If you need the value of the URI, catch {@link AuthleteApiException}
+     * and call {@link AuthleteApiException#getResponseHeaders() getResponseHeaders()}.
+     * </p>
+     *
+     * @param pretty
+     *         {@code true} to get the JSON in pretty format.
+     *
+     * @param includePrivateKeys
+     *         {@code true} to keep private keys in the JSON. {@code false} to
+     *         remove private keys.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         JSON representation of the JWK Set of the service.
+     *         {@code null} is returned when the service has registered
+     *         neither content or URI of its JWK Set.
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7517">RFC 7517: JSON Web Key (JWK)</a>
+     *
+     * @since 4.15
+     */
+    String getServiceJwks(boolean pretty, boolean includePrivateKeys, Options options) throws AuthleteApiException;
 
 
     /**
@@ -972,7 +2016,34 @@ public interface AuthleteApi
      *
      * @since 1.27
      */
-    String getServiceConfiguration() throws AuthleteApiException;
+    default String getServiceConfiguration() throws AuthleteApiException
+    {
+        return getServiceConfiguration((Options)null);
+    }
+
+
+    /**
+     * Get the configuration of the service in JSON format that complies with
+     * <a href="https://openid.net/specs/openid-connect-discovery-1_0.html"
+     * >OpenID Connect Discovery 1.0</a>.
+     *
+     * <p>
+     * This method is an alias of {@link #getServiceConfiguration(boolean)
+     * getServiceConfiguration}{@code (true)}.
+     * </p>
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         The configuration of the service in JSON format.
+     *
+     * @see <a href="https://openid.net/specs/openid-connect-discovery-1_0.html"
+     *      >OpenID Connect Discovery 1.0</a>
+     *
+     * @since 4.15
+     */
+    String getServiceConfiguration(Options options) throws AuthleteApiException;
 
 
     /**
@@ -999,7 +2070,40 @@ public interface AuthleteApi
      *
      * @since 1.28
      */
-    String getServiceConfiguration(boolean pretty) throws AuthleteApiException;
+    default String getServiceConfiguration(boolean pretty) throws AuthleteApiException
+    {
+        return getServiceConfiguration(pretty, null);
+    }
+
+
+    /**
+     * Get the configuration of the service in JSON format that complies with
+     * <a href="https://openid.net/specs/openid-connect-discovery-1_0.html"
+     * >OpenID Connect Discovery 1.0</a>.
+     *
+     * <p>
+     * The value returned from this method can be used as the response body
+     * from {@code /.well-known/openid-configuration}. See "<a href=
+     * "https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig"
+     * >4. Obtaining OpenID Provider Configuration Information</a>" in OpenID
+     * Connect Discovery 1.0 for details.
+     * </p>
+     *
+     * @param pretty
+     *         {@code true} to get the JSON in pretty format.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         The configuration of the service in JSON format.
+     *
+     * @see <a href="https://openid.net/specs/openid-connect-discovery-1_0.html"
+     *      >OpenID Connect Discovery 1.0</a>
+     *
+     * @since 4.15
+     */
+    String getServiceConfiguration(boolean pretty, Options options) throws AuthleteApiException;
 
 
     /**
@@ -1023,7 +2127,37 @@ public interface AuthleteApi
      *
      * @since 3.44
      */
-    String getServiceConfiguration(ServiceConfigurationRequest request) throws AuthleteApiException;
+    default String getServiceConfiguration(ServiceConfigurationRequest request) throws AuthleteApiException
+    {
+        return getServiceConfiguration(request, null);
+    }
+
+
+    /**
+     * Get the configuration of the service in JSON format that complies with
+     * <a href="https://openid.net/specs/openid-connect-discovery-1_0.html"
+     * >OpenID Connect Discovery 1.0</a>.
+     *
+     * <p>
+     * The value returned from this method can be used as the response body
+     * from {@code /.well-known/openid-configuration}. See "<a href=
+     * "https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig"
+     * >4. Obtaining OpenID Provider Configuration Information</a>" in OpenID
+     * Connect Discovery 1.0 for details.
+     * </p>
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         The configuration of the service in JSON format.
+     *
+     * @since 4.15
+     */
+    String getServiceConfiguration(ServiceConfigurationRequest request, Options options) throws AuthleteApiException;
 
 
     /**
@@ -1035,7 +2169,27 @@ public interface AuthleteApi
      * @return
      *         Information about a newly created client.
      */
-    Client createClient(Client client) throws AuthleteApiException;
+    default Client createClient(Client client) throws AuthleteApiException
+    {
+        return createClient(client, null);
+    }
+
+
+    /**
+     * Create a client (= call Authlete's {@code /client/create} API).
+     *
+     * @param client
+     *         Information about a client to create.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Information about a newly created client.
+     *
+     * @since 4.15
+     */
+    Client createClient(Client client, Options options) throws AuthleteApiException;
 
 
     /**
@@ -1053,7 +2207,31 @@ public interface AuthleteApi
      *
      * @since 2.41
      */
-    ClientRegistrationResponse dynamicClientRegister(ClientRegistrationRequest request) throws AuthleteApiException;
+    default ClientRegistrationResponse dynamicClientRegister(ClientRegistrationRequest request) throws AuthleteApiException
+    {
+        return dynamicClientRegister(request, null);
+    }
+
+
+    /**
+     * Register a client (= call Authlete's {@code /client/registration} API).
+     *
+     * This method can be used to implement a client registration endpoint
+     * that complies with <a href="https://tools.ietf.org/html/rfc7591">RFC 7591</a>
+     * (OAuth 2.0 Dynamic Client Registration Protocol).
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     */
+    ClientRegistrationResponse dynamicClientRegister(ClientRegistrationRequest request, Options options) throws AuthleteApiException;
 
 
     /**
@@ -1072,7 +2250,32 @@ public interface AuthleteApi
      *
      * @since 2.41
      */
-    ClientRegistrationResponse dynamicClientGet(ClientRegistrationRequest request) throws AuthleteApiException;
+    default ClientRegistrationResponse dynamicClientGet(ClientRegistrationRequest request) throws AuthleteApiException
+    {
+        return dynamicClientGet(request, null);
+    }
+
+
+    /**
+     * Get a dynamically registered client (= call Authlete's
+     * {@code /client/registration/get} API).
+     *
+     * This method can be used to implement a client registration management endpoint
+     * that complies with <a href="https://tools.ietf.org/html/rfc7592">RFC 7592</a>
+     * (OAuth 2.0 Dynamic Client Registration Management Protocol).
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     */
+    ClientRegistrationResponse dynamicClientGet(ClientRegistrationRequest request, Options options) throws AuthleteApiException;
 
 
     /**
@@ -1091,7 +2294,32 @@ public interface AuthleteApi
      *
      * @since 2.41
      */
-    ClientRegistrationResponse dynamicClientUpdate(ClientRegistrationRequest request) throws AuthleteApiException;
+    default ClientRegistrationResponse dynamicClientUpdate(ClientRegistrationRequest request) throws AuthleteApiException
+    {
+        return dynamicClientUpdate(request, null);
+    }
+
+
+    /**
+     * Update a dynamically registered client (= call Authlete's
+     * {@code /client/registration/update} API).
+     *
+     * This method can be used to implement a client registration management endpoint
+     * that complies with <a href="https://tools.ietf.org/html/rfc7592">RFC 7592</a>
+     * (OAuth 2.0 Dynamic Client Registration Management Protocol).
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     */
+    ClientRegistrationResponse dynamicClientUpdate(ClientRegistrationRequest request, Options options) throws AuthleteApiException;
 
 
     /**
@@ -1110,7 +2338,32 @@ public interface AuthleteApi
      *
      * @since 2.41
      */
-    ClientRegistrationResponse dynamicClientDelete(ClientRegistrationRequest request) throws AuthleteApiException;
+    default ClientRegistrationResponse dynamicClientDelete(ClientRegistrationRequest request) throws AuthleteApiException
+    {
+        return dynamicClientDelete(request, null);
+    }
+
+
+    /**
+     * Delete a dynamically registered client (= call Authlete's
+     * {@code /client/registration/delete} API).
+     *
+     * This method can be used to implement a client registration management endpoint
+     * that complies with <a href="https://tools.ietf.org/html/rfc7592">RFC 7592</a>
+     * (OAuth 2.0 Dynamic Client Registration Management Protocol).
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     */
+    ClientRegistrationResponse dynamicClientDelete(ClientRegistrationRequest request, Options options) throws AuthleteApiException;
 
 
     /**
@@ -1119,7 +2372,24 @@ public interface AuthleteApi
      * @param clientId
      *         Client ID.
      */
-    void deleteClient(long clientId) throws AuthleteApiException;
+    default void deleteClient(long clientId) throws AuthleteApiException
+    {
+        deleteClient(clientId, null);
+    }
+
+
+    /**
+     * Delete a client (= call Authlete's <code>/client/delete/{clientId}</code> API).
+     *
+     * @param clientId
+     *         Client ID.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @since 4.15
+     */
+    void deleteClient(long clientId, Options options) throws AuthleteApiException;
 
 
     /**
@@ -1130,7 +2400,24 @@ public interface AuthleteApi
      *
      * @since 2.51
      */
-    void deleteClient(String clientId) throws AuthleteApiException;
+    default void deleteClient(String clientId) throws AuthleteApiException
+    {
+        deleteClient(clientId, null);
+    }
+
+
+    /**
+     * Delete a client (= call Authlete's <code>/client/delete/{clientId}</code> API).
+     *
+     * @param clientId
+     *         Client ID.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @since 4.15
+     */
+    void deleteClient(String clientId, Options options) throws AuthleteApiException;
 
 
     /**
@@ -1142,7 +2429,27 @@ public interface AuthleteApi
      * @return
      *         Information about the client.
      */
-    Client getClient(long clientId) throws AuthleteApiException;
+    default Client getClient(long clientId) throws AuthleteApiException
+    {
+        return getClient(clientId, null);
+    }
+
+
+    /**
+     * Get a client (= call Authlete's <code>/client/get/{clientId}</code> API).
+     *
+     * @param clientId
+     *         The client ID.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Information about the client.
+     *
+     * @since 4.15
+     */
+    Client getClient(long clientId, Options options) throws AuthleteApiException;
 
 
     /**
@@ -1156,7 +2463,27 @@ public interface AuthleteApi
      *
      * @since 2.51
      */
-    Client getClient(String clientId) throws AuthleteApiException;
+    default Client getClient(String clientId) throws AuthleteApiException
+    {
+        return getClient(clientId, null);
+    }
+
+
+    /**
+     * Get a client (= call Authlete's <code>/client/get/{clientId}</code> API).
+     *
+     * @param clientId
+     *         The client ID.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Information about the client.
+     *
+     * @since 4.15
+     */
+    Client getClient(String clientId, Options options) throws AuthleteApiException;
 
 
     /**
@@ -1172,7 +2499,31 @@ public interface AuthleteApi
      * @return
      *         The list of clients.
      */
-    ClientListResponse getClientList() throws AuthleteApiException;
+    default ClientListResponse getClientList() throws AuthleteApiException
+    {
+        return getClientList((Options)null);
+    }
+
+
+    /**
+     * Get the list of client applications that belong to the service
+     * (= call Authlete's {@code /client/get/list} API).
+     *
+     * <p>
+     * This method uses the default range to limit the result set
+     * of the query. Use {@link #getClientList(int, int)} to specify
+     * the range explicitly.
+     * </p>
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         The list of clients.
+     *
+     * @since 4.15
+     */
+    ClientListResponse getClientList(Options options) throws AuthleteApiException;
 
 
     /**
@@ -1197,7 +2548,40 @@ public interface AuthleteApi
      * @return
      *         The list of clients.
      */
-    ClientListResponse getClientList(String developer) throws AuthleteApiException;
+    default ClientListResponse getClientList(String developer) throws AuthleteApiException
+    {
+        return getClientList(developer, null);
+    }
+
+
+    /**
+     * Get the list of client applications that belong to the developer
+     * (= call Authlete's {@code /client/get/list} API with {@code
+     * developer} parameter).
+     *
+     * <p>
+     * When {@code developer} is {@code null}, the list of client
+     * applications that belong to the service is returned.
+     * </p>
+     *
+     * <p>
+     * This method uses the default range to limit the result set
+     * of the query. Use {@link #getClientList(String, int, int)}
+     * to specify the range explicitly.
+     * </p>
+     *
+     * @param developer
+     *         The developer of the targeted client applications.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         The list of clients.
+     *
+     * @since 4.15
+     */
+    ClientListResponse getClientList(String developer, Options options) throws AuthleteApiException;
 
 
     /**
@@ -1216,7 +2600,34 @@ public interface AuthleteApi
      * @return
      *         The list of clients.
      */
-    ClientListResponse getClientList(int start, int end) throws AuthleteApiException;
+    default ClientListResponse getClientList(int start, int end) throws AuthleteApiException
+    {
+        return getClientList(start, end, null);
+    }
+
+
+    /**
+     * Get the list of client applications that belong to the service
+     * (= call Authlete's {@code /client/get/list} API with {@code
+     * start} and {@code end} parameters).
+     *
+     * @param start
+     *         The start index (inclusive) of the result set of the query.
+     *         Must not be negative.
+     *
+     * @param end
+     *         The end index (exclusive) of the result set of the query.
+     *         Must not be negative.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         The list of clients.
+     *
+     * @since 4.15
+     */
+    ClientListResponse getClientList(int start, int end, Options options) throws AuthleteApiException;
 
 
     /**
@@ -1274,7 +2685,73 @@ public interface AuthleteApi
      * @return
      *         The list of client applications.
      */
-    ClientListResponse getClientList(String developer, int start, int end) throws AuthleteApiException;
+    default ClientListResponse getClientList(String developer, int start, int end) throws AuthleteApiException
+    {
+        return getClientList(developer, start, end, null);
+    }
+
+
+    /**
+     * Get the list of client applications
+     * (= call Authlete's {@code /client/get/list} API with {@code
+     * developer}, {@code start} and {@code end} parameters).
+     *
+     * <p>
+     * When {@code developer} is {@code null}, the list of client
+     * applications that belong to the service is returned.
+     * Otherwise, when {@code developer} is not {@code null}, the
+     * list of client applications that belong to the developer is
+     * returned.
+     * </p>
+     *
+     * <p>
+     * The pair of {@code start} and {@code end} parameters denotes
+     * the range of the result set of the query. For example, if
+     * {@code start} is 5 and {@code end} is 7, the pair makes a
+     * range from 5 (inclusive) to 7 (exclusive) and the response
+     * will contain (at most) 2 pieces of client information, i.e.,
+     * information about the 6th and the 7th applications (the
+     * index starts from 0).
+     * </p>
+     *
+     * <p>
+     * If {@code end - start} is equal to or less than 0, {@link
+     * ClientListResponse#getClients() getClients()} method of the
+     * response returns {@code null}. But even in such a case,
+     * {@link ClientListResponse#getTotalCount() getTotalCount()}
+     * method returns the total count. In other words, if you want
+     * to get just the total count, you can write the code as
+     * shown below.
+     * </p>
+     *
+     * <pre>
+     * int totalCount = api.{@link #getClientList(String, int, int)
+     * getClientList(developer, 0, 0)}.{@link ClientListResponse#getTotalCount()
+     * getTotalCount()};
+     * </pre>
+     *
+     * @param developer
+     *         The developer of the targeted client applications,
+     *         or {@code null} to get the list of client applications
+     *         of the entire service.
+     *
+     * @param start
+     *         The start index (inclusive) of the result set of the query.
+     *         Must not be negative.
+     *
+     * @param end
+     *         The end index (exclusive) of the result set of the query.
+     *         Must not be negative.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         The list of clients.
+     *
+     * @since 4.15
+     */
+    ClientListResponse getClientList(String developer, int start, int end, Options options) throws AuthleteApiException;
 
 
     /**
@@ -1291,7 +2768,32 @@ public interface AuthleteApi
      * @return
      *         Information about the updated client.
      */
-    Client updateClient(Client client) throws AuthleteApiException;
+    default Client updateClient(Client client) throws AuthleteApiException
+    {
+        return updateClient(client, null);
+    }
+
+
+    /**
+     * Update a client (= call Authlete's <code>/client/update/{clientId}</code> API).
+     *
+     * <p>
+     * {@code client.}{@link Client#getClientId() getClientId()} must
+     * return the correct client ID.
+     * </p>
+     *
+     * @param client
+     *         Information about a client to update.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Information about the updated client.
+     *
+     * @since 4.15
+     */
+    Client updateClient(Client client, Options options) throws AuthleteApiException;
 
 
     /**
@@ -1323,7 +2825,45 @@ public interface AuthleteApi
      *
      * @since 1.34
      */
-    String[] getRequestableScopes(long clientId) throws AuthleteApiException;
+    default String[] getRequestableScopes(long clientId) throws AuthleteApiException
+    {
+        return getRequestableScopes(clientId, null);
+    }
+
+
+    /**
+     * Get the requestable scopes assigned to a client (= call Authlete's
+     * <code>/client/extension/requestable_scopes/get/{clientId}</code> API).
+     *
+     * @param clientId
+     *         A client ID.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         <dl>
+     *           <dt>null</dt>
+     *           <dd>
+     *             Requestable scopes are not assigned to the client, meaning
+     *             that the client can request any scopes supported by the service.
+     *           </dd>
+     *           <dt>An empty array</dt>
+     *           <dd>
+     *             The client cannot request any scopes, meaning that values
+     *             included in the {@code scope} request parameter in authorization
+     *             requests and token requests are all ignored.
+     *           </dd>
+     *           <dt>An array of scope names</dt>
+     *           <dd>
+     *             The array represents the set of scopes that the client is allowed
+     *             to request.
+     *           </dd>
+     *         </dl>
+     *
+     * @since 4.15
+     */
+    String[] getRequestableScopes(long clientId, Options options) throws AuthleteApiException;
 
 
     /**
@@ -1383,7 +2923,73 @@ public interface AuthleteApi
      *
      * @since 1.34
      */
-    String[] setRequestableScopes(long clientId, String[] scopes) throws AuthleteApiException;
+    default String[] setRequestableScopes(long clientId, String[] scopes) throws AuthleteApiException
+    {
+        return setRequestableScopes(clientId, scopes, null);
+    }
+
+
+    /**
+     * Set the requestable scopes assigned to a client (= call Authlete's
+     * <code>/client/extension/requestable_scopes/update/{clientId}</code> API).
+     *
+     * <p>
+     * Calling this method with {@code scopes=null} has the same effect as calling
+     * {@link #deleteRequestableScopes(long) deleteRequestableScopes(clientId)}.
+     * </p>
+     *
+     * <p>
+     * Since the version 1.39, the {@link Client} class has {@code extension}
+     * property and information about <i>"Requestable Scopes per Client"</i>
+     * is included in the property. So, calling <code>/client/update/{clientId}</code>
+     * API is enough and recommended. In other words, calling
+     * <code>/client/extension/requestable_scopes/update/{clientId}</code> API
+     * is no longer recommended.
+     * </p>
+     *
+     * <p>
+     * Known issue: The JSON parser used by the implementation of
+     * <code>/client/extension/requestable_scopes/update/{clientId}</code> API
+     * treats an empty array as null and it does not provide any configuration
+     * method to change the behavior. Until the JSON parser is replaced, passing
+     * an empty array to the API leads to the same result as passing {@code null}
+     * to the API.
+     * </p>
+     *
+     * @param clientId
+     *         A client ID.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @param scopes
+     *         <dl>
+     *           <dt>null</dt>
+     *           <dd>
+     *             Requestable scopes assigned to the client are cleared. This
+     *             results in that the client can request any scopes supported
+     *             by the service.
+     *           </dd>
+     *           <dt>An empty array</dt>
+     *           <dd>
+     *             The client cannot request any scopes, meaning that values included
+     *             in the {@code scope} request parameter in authorization requests
+     *             and token requests are all ignored.
+     *           </dd>
+     *           <dt>An array of scope names</dt>
+     *           <dd>
+     *             The given array is used as the set of scopes that the client is
+     *             allowed to request.
+     *           </dd>
+     *         </dl>
+     *
+     * @return
+     *         The resultant set of requestable scopes. The value may be different
+     *         from the one given to this method.
+     *
+     * @since 4.15
+     */
+    String[] setRequestableScopes(long clientId, String[] scopes, Options options) throws AuthleteApiException;
 
 
     /**
@@ -1400,7 +3006,30 @@ public interface AuthleteApi
      *
      * @since 1.34
      */
-    void deleteRequestableScopes(long clientId) throws AuthleteApiException;
+    default void deleteRequestableScopes(long clientId) throws AuthleteApiException
+    {
+        deleteRequestableScopes(clientId, null);
+    }
+
+
+    /**
+     * Clear the requestable scopes assigned to a client (= call Authlete's
+     * <code>/client/extension/requestable_scopes/delete/{clientId}</code> API).
+     *
+     * <p>
+     * Calling this method has the same effect as calling {@link #setRequestableScopes(long, String[])
+     * setRequestableScopes(clientId, null)}.
+     * </p>
+     *
+     * @param clientId
+     *         A client ID.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @since 4.15
+     */
+    void deleteRequestableScopes(long clientId, Options options) throws AuthleteApiException;
 
 
     /**
@@ -1427,7 +3056,40 @@ public interface AuthleteApi
      *
      * @since 1.39
      */
-    GrantedScopesGetResponse getGrantedScopes(long clientId, String subject);
+    default GrantedScopesGetResponse getGrantedScopes(long clientId, String subject)
+    {
+        return getGrantedScopes(clientId, subject, null);
+    }
+
+
+    /**
+     * Get the set of scopes that a user has granted to a client application
+     * (call Authlete's <code>/client/granted_scopes/get/{clientId}</code> API).
+     *
+     * <p>
+     * A dedicated Authlete server provides a functionality to remember the set
+     * of scopes that a user has granted to a client application. A remembered
+     * set is NOT removed from the database even after all existing access tokens
+     * associated with the combination of the client application and the subject
+     * have expired. Note that this functionality is not provided by the shared
+     * Authlete server.
+     * </p>
+     *
+     * @param clientId
+     *         A client ID.
+     *
+     * @param subject
+     *         A unique user identifier.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Information about scopes granted to a client application by a user.
+     *
+     * @since 4.15
+     */
+    GrantedScopesGetResponse getGrantedScopes(long clientId, String subject, Options options);
 
 
     /**
@@ -1455,7 +3117,41 @@ public interface AuthleteApi
      *
      * @since 1.40
      */
-    void deleteGrantedScopes(long clientId, String subject);
+    default void deleteGrantedScopes(long clientId, String subject)
+    {
+        deleteGrantedScopes(clientId, subject, null);
+    }
+
+
+    /**
+     * Delete DB records about the set of scopes that a user has granted to a
+     * client application (call Authlete's
+     * <code>/client/granted_scopes/delete/{clientId}</code> API).
+     *
+     * <p>
+     * Even if you delete records about granted scopes by calling this API,
+     * existing access tokens are not deleted and scopes of existing access
+     * tokens are not changed.
+     * </p>
+     *
+     * <p>
+     * Please call this method if the user identified by the subject is deleted
+     * from your system. Otherwise, garbage data continue to exist in the
+     * database.
+     * </p>
+     *
+     * @param clientId
+     *         A client ID.
+     *
+     * @param subject
+     *         A unique user identifier.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @since 4.15
+     */
+    void deleteGrantedScopes(long clientId, String subject, Options options);
 
 
     /**
@@ -1471,7 +3167,29 @@ public interface AuthleteApi
      *
      * @since 2.1
      */
-    void deleteClientAuthorization(long clientId, String subject) throws AuthleteApiException;
+    default void deleteClientAuthorization(long clientId, String subject) throws AuthleteApiException
+    {
+        deleteClientAuthorization(clientId, subject, null);
+    }
+
+
+    /**
+     * Delete all existing access tokens issued to the client application
+     * by the end-user.
+     *
+     * @param clientId
+     *         The ID of the target client application.
+     *
+     * @param subject
+     *         The subject (= unique identifier) of the end-user.
+     *         Must not be {@code null}.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @since 4.15
+     */
+    void deleteClientAuthorization(long clientId, String subject, Options options) throws AuthleteApiException;
 
 
     /**
@@ -1488,7 +3206,30 @@ public interface AuthleteApi
      *
      * @since 2.1
      */
-    AuthorizedClientListResponse getClientAuthorizationList(ClientAuthorizationGetListRequest request) throws AuthleteApiException;
+    default AuthorizedClientListResponse getClientAuthorizationList(ClientAuthorizationGetListRequest request) throws AuthleteApiException
+    {
+        return getClientAuthorizationList(request, null);
+    }
+
+
+    /**
+     * Get a list of client applications authorized by the end-user.
+     *
+     * @param request
+     *         Conditions to query the list. The {@code subject} property
+     *         (= the unique identifier of the end-user) in the request
+     *         must not be {@code null}.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         A list of client applications that have been authorized
+     *         by the end-user.
+     *
+     * @since 4.15
+     */
+    AuthorizedClientListResponse getClientAuthorizationList(ClientAuthorizationGetListRequest request, Options options) throws AuthleteApiException;
 
 
     /**
@@ -1505,7 +3246,30 @@ public interface AuthleteApi
      *
      * @since 2.1
      */
-    void updateClientAuthorization(long clientId, ClientAuthorizationUpdateRequest request) throws AuthleteApiException;
+    default void updateClientAuthorization(long clientId, ClientAuthorizationUpdateRequest request) throws AuthleteApiException
+    {
+        updateClientAuthorization(clientId, request, null);
+    }
+
+
+    /**
+     * Update attributes of all existing access tokens issued to the
+     * client application by the end-user.
+     *
+     * @param clientId
+     *         The ID of the target client application.
+     *
+     * @param request
+     *         The subject (= unique identifier) of the end-user and new attribute
+     *         values of access tokens. The {@code subject} property in the request
+     *         must not be {@code null}.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @since 4.15
+     */
+    void updateClientAuthorization(long clientId, ClientAuthorizationUpdateRequest request, Options options) throws AuthleteApiException;
 
 
     /**
@@ -1522,7 +3286,30 @@ public interface AuthleteApi
      *
      * @since 2.11
      */
-    ClientSecretRefreshResponse refreshClientSecret(long clientId) throws AuthleteApiException;
+    default ClientSecretRefreshResponse refreshClientSecret(long clientId) throws AuthleteApiException
+    {
+        return refreshClientSecret(clientId, null);
+    }
+
+
+    /**
+     * Refresh the client secret of a client. A new value of the
+     * client secret will be generated by the Authlete server.
+     * If you want to specify a new value, use {@link
+     * #updateClientSecret(long, String) updateClientSecret} method.
+     *
+     * @param clientId
+     *         The client ID of a client.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         A response from Authlete's {@code /api/client/secret/refresh} API.
+     *
+     * @since 4.15
+     */
+    ClientSecretRefreshResponse refreshClientSecret(long clientId, Options options) throws AuthleteApiException;
 
 
     /**
@@ -1539,7 +3326,30 @@ public interface AuthleteApi
      *
      * @since 2.11
      */
-    ClientSecretRefreshResponse refreshClientSecret(String clientIdentifier) throws AuthleteApiException;
+    default ClientSecretRefreshResponse refreshClientSecret(String clientIdentifier) throws AuthleteApiException
+    {
+        return refreshClientSecret(clientIdentifier, null);
+    }
+
+
+    /**
+     * Refresh the client secret of a client. A new value of the
+     * client secret will be generated by the Authlete server.
+     * If you want to specify a new value, use {@link
+     * #updateClientSecret(String, String) updateClientSecret} method.
+     *
+     * @param clientIdentifier
+     *         The client ID or the client ID alias of a client.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         A response from Authlete's {@code /api/client/secret/refresh} API.
+     *
+     * @since 4.15
+     */
+    ClientSecretRefreshResponse refreshClientSecret(String clientIdentifier, Options options) throws AuthleteApiException;
 
 
     /**
@@ -1565,8 +3375,41 @@ public interface AuthleteApi
      *
      * @since 2.11
      */
+    default ClientSecretUpdateResponse updateClientSecret(
+            long clientId, String clientSecret) throws AuthleteApiException
+    {
+        return updateClientSecret(clientId, clientSecret, null);
+    }
+
+
+    /**
+     * Update the client secret of a client. If you want to
+     * have the Authlete server generate a new value of the
+     * client secret, use {@link #refreshClientSecret(long)
+     * refreshClientSecret} method.
+     *
+     * <p>
+     * Valid characters for a client secret are {@code A-Z},
+     * {@code a-z}, {@code 0-9}, {@code -}, and {@code _}.
+     * The maximum length of a client secret is 86.
+     * </p>
+     *
+     * @param clientId
+     *         The client ID of a client.
+     *
+     * @param clientSecret
+     *         The new value of the client secret.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         A response from Authlete's {@code /api/client/secret/update} API.
+     *
+     * @since 4.15
+     */
     ClientSecretUpdateResponse updateClientSecret(
-            long clientId, String clientSecret) throws AuthleteApiException;
+            long clientId, String clientSecret, Options options) throws AuthleteApiException;
 
 
     /**
@@ -1592,8 +3435,41 @@ public interface AuthleteApi
      *
      * @since 2.11
      */
+    default ClientSecretUpdateResponse updateClientSecret(
+            String clientIdentifier, String clientSecret) throws AuthleteApiException
+    {
+        return updateClientSecret(clientIdentifier, clientSecret, null);
+    }
+
+
+    /**
+     * Update the client secret of a client. If you want to
+     * have the Authlete server generate a new value of the
+     * client secret, use {@link #refreshClientSecret(String)
+     * refreshClientSecret} method.
+     *
+     * <p>
+     * Valid characters for a client secret are {@code A-Z},
+     * {@code a-z}, {@code 0-9}, {@code -}, and {@code _}.
+     * The maximum length of a client secret is 86.
+     * </p>
+     *
+     * @param clientIdentifier
+     *         The client ID or the client ID alias of a client.
+     *
+     * @param clientSecret
+     *         The new value of the client secret.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         A response from Authlete's {@code /api/client/secret/update} API.
+     *
+     * @since 4.15
+     */
     ClientSecretUpdateResponse updateClientSecret(
-            String clientIdentifier, String clientSecret) throws AuthleteApiException;
+            String clientIdentifier, String clientSecret, Options options) throws AuthleteApiException;
 
 
     /**
@@ -1620,7 +3496,27 @@ public interface AuthleteApi
      *
      * @since 2.23
      */
-    JoseVerifyResponse verifyJose(JoseVerifyRequest request) throws AuthleteApiException;
+    default JoseVerifyResponse verifyJose(JoseVerifyRequest request) throws AuthleteApiException
+    {
+        return verifyJose(request, null);
+    }
+
+
+    /**
+     * Verify a JOSE object.
+     *
+     * @param request
+     *         A request to Authlete's {@code /api/jose/verify} API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         A response from Authlete's {@code /api/jose/verify} API.
+     *
+     * @since 4.15
+     */
+    JoseVerifyResponse verifyJose(JoseVerifyRequest request, Options options) throws AuthleteApiException;
 
 
     /**
@@ -1634,8 +3530,29 @@ public interface AuthleteApi
      *
      * @since 2.32
      */
+    default BackchannelAuthenticationResponse backchannelAuthentication(
+            BackchannelAuthenticationRequest request) throws AuthleteApiException
+    {
+        return backchannelAuthentication(request, null);
+    }
+
+
+    /**
+     * Call Authlete's {@code /api/backchannel/authentication} API.
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     */
     BackchannelAuthenticationResponse backchannelAuthentication(
-            BackchannelAuthenticationRequest request) throws AuthleteApiException;
+            BackchannelAuthenticationRequest request, Options options) throws AuthleteApiException;
 
 
     /**
@@ -1649,8 +3566,29 @@ public interface AuthleteApi
      *
      * @since 2.32
      */
+    default BackchannelAuthenticationIssueResponse backchannelAuthenticationIssue(
+            BackchannelAuthenticationIssueRequest request) throws AuthleteApiException
+    {
+        return backchannelAuthenticationIssue(request, null);
+    }
+
+
+    /**
+     * Call Authlete's {@code /api/backchannel/authentication/issue} API.
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     */
     BackchannelAuthenticationIssueResponse backchannelAuthenticationIssue(
-            BackchannelAuthenticationIssueRequest request) throws AuthleteApiException;
+            BackchannelAuthenticationIssueRequest request, Options options) throws AuthleteApiException;
 
 
     /**
@@ -1664,8 +3602,29 @@ public interface AuthleteApi
      *
      * @since 2.32
      */
+    default BackchannelAuthenticationFailResponse backchannelAuthenticationFail(
+            BackchannelAuthenticationFailRequest request) throws AuthleteApiException
+    {
+        return backchannelAuthenticationFail(request, null);
+    }
+
+
+    /**
+     * Call Authlete's {@code /api/backchannel/authentication/fail} API.
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     */
     BackchannelAuthenticationFailResponse backchannelAuthenticationFail(
-            BackchannelAuthenticationFailRequest request) throws AuthleteApiException;
+            BackchannelAuthenticationFailRequest request, Options options) throws AuthleteApiException;
 
 
     /**
@@ -1679,8 +3638,29 @@ public interface AuthleteApi
      *
      * @since 2.32
      */
+    default BackchannelAuthenticationCompleteResponse backchannelAuthenticationComplete(
+            BackchannelAuthenticationCompleteRequest request) throws AuthleteApiException
+    {
+        return backchannelAuthenticationComplete(request, null);
+    }
+
+
+    /**
+     * Call Authlete's {@code /api/backchannel/authentication/complete} API.
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     */
     BackchannelAuthenticationCompleteResponse backchannelAuthenticationComplete(
-            BackchannelAuthenticationCompleteRequest request) throws AuthleteApiException;
+            BackchannelAuthenticationCompleteRequest request, Options options) throws AuthleteApiException;
 
 
     /**
@@ -1694,8 +3674,29 @@ public interface AuthleteApi
      *
      * @since 2.42
      */
+    default DeviceAuthorizationResponse deviceAuthorization(
+            DeviceAuthorizationRequest request) throws AuthleteApiException
+    {
+        return deviceAuthorization(request, null);
+    }
+
+
+    /**
+     * Call Authlete's {@code /api/device/authorization} API.
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     */
     DeviceAuthorizationResponse deviceAuthorization(
-            DeviceAuthorizationRequest request) throws AuthleteApiException;
+            DeviceAuthorizationRequest request, Options options) throws AuthleteApiException;
 
 
     /**
@@ -1709,8 +3710,29 @@ public interface AuthleteApi
      *
      * @since 2.42
      */
+    default DeviceCompleteResponse deviceComplete(
+            DeviceCompleteRequest request) throws AuthleteApiException
+    {
+        return deviceComplete(request, null);
+    }
+
+
+    /**
+     * Call Authlete's {@code /api/device/complete} API.
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     */
     DeviceCompleteResponse deviceComplete(
-            DeviceCompleteRequest request) throws AuthleteApiException;
+            DeviceCompleteRequest request, Options options) throws AuthleteApiException;
 
 
     /**
@@ -1724,8 +3746,29 @@ public interface AuthleteApi
      *
      * @since 2.42
      */
+    default DeviceVerificationResponse deviceVerification(
+            DeviceVerificationRequest request) throws AuthleteApiException
+    {
+        return deviceVerification(request, null);
+    }
+
+
+    /**
+     * Call Authlete's {@code /api/device/verification} API.
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     */
     DeviceVerificationResponse deviceVerification(
-            DeviceVerificationRequest request) throws AuthleteApiException;
+            DeviceVerificationRequest request, Options options) throws AuthleteApiException;
 
 
     /**
@@ -1739,8 +3782,29 @@ public interface AuthleteApi
      *
      * @since 2.51
      */
+    default PushedAuthReqResponse pushAuthorizationRequest(
+            PushedAuthReqRequest request) throws AuthleteApiException
+    {
+        return pushAuthorizationRequest(request, null);
+    }
+
+
+    /**
+     * Call Authlete's {@code /api/pushed_auth_req} API.
+     *
+     * @param request
+     *            Request parameters passed to the API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     */
     PushedAuthReqResponse pushAuthorizationRequest(
-            PushedAuthReqRequest request) throws AuthleteApiException;
+            PushedAuthReqRequest request, Options options) throws AuthleteApiException;
 
 
     /**
@@ -1754,7 +3818,27 @@ public interface AuthleteApi
      *
      * @since 2.97
      */
-    HskResponse hskCreate(HskCreateRequest request) throws AuthleteApiException;
+    default HskResponse hskCreate(HskCreateRequest request) throws AuthleteApiException
+    {
+        return hskCreate(request, null);
+    }
+
+
+    /**
+     * Call Authlete's {@code /api/hsk/create} API.
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     */
+    HskResponse hskCreate(HskCreateRequest request, Options options) throws AuthleteApiException;
 
 
     /**
@@ -1768,7 +3852,27 @@ public interface AuthleteApi
      *
      * @since 2.97
      */
-    HskResponse hskDelete(String handle) throws AuthleteApiException;
+    default HskResponse hskDelete(String handle) throws AuthleteApiException
+    {
+        return hskDelete(handle, null);
+    }
+
+
+    /**
+     * Call Authlete's <code>/api/hsk/delete/{handle}</code> API.
+     *
+     * @param handle
+     *         The handle for the target record.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     */
+    HskResponse hskDelete(String handle, Options options) throws AuthleteApiException;
 
 
     /**
@@ -1782,7 +3886,27 @@ public interface AuthleteApi
      *
      * @since 2.97
      */
-    HskResponse hskGet(String handle) throws AuthleteApiException;
+    default HskResponse hskGet(String handle) throws AuthleteApiException
+    {
+        return hskGet(handle, null);
+    }
+
+
+    /**
+     * Call Authlete's <code>/api/hsk/get/{handle}</code> API.
+     *
+     * @param handle
+     *         The handle for the target record.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     */
+    HskResponse hskGet(String handle, Options options) throws AuthleteApiException;
 
 
     /**
@@ -1793,7 +3917,24 @@ public interface AuthleteApi
      *
      * @since 2.97
      */
-    HskListResponse hskGetList() throws AuthleteApiException;
+    default HskListResponse hskGetList() throws AuthleteApiException
+    {
+        return hskGetList(null);
+    }
+
+
+    /**
+     * Call Authlete's {@code /api/hsk/get/list} API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     */
+    HskListResponse hskGetList(Options options) throws AuthleteApiException;
 
 
     /**
@@ -1811,7 +3952,31 @@ public interface AuthleteApi
      *
      * @since 3.0
      */
-    Map<String, String> echo(Map<String, String> parameters) throws AuthleteApiException;
+    default Map<String, String> echo(Map<String, String> parameters) throws AuthleteApiException
+    {
+        return echo(parameters, null);
+    }
+
+
+    /**
+     * Call Authlete's {@code /api/misc/echo} API.
+     *
+     * <p>
+     * The API returns a JSON string which contains given request parameters.
+     * </p>
+     *
+     * @param parameters
+     *         Arbitrary parameters.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     */
+    Map<String, String> echo(Map<String, String> parameters, Options option) throws AuthleteApiException;
 
 
     /**
@@ -1834,7 +3999,36 @@ public interface AuthleteApi
      *
      * @since 3.1
      */
-    GMResponse gm(GMRequest request) throws AuthleteApiException;
+    default GMResponse gm(GMRequest request) throws AuthleteApiException
+    {
+        return gm(request, null);
+    }
+
+
+    /**
+     * Call Authlete's {@code /api/gm} API.
+     *
+     * <p>
+     * The API is for the implementation of the grant management endpoint which is
+     * defined in "<a href="https://openid.net/specs/fapi-grant-management.html"
+     * >Grant Management for OAuth 2.0</a>".
+     * </p>
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @see <a href="https://openid.net/specs/fapi-grant-management.html"
+     *      >Grant Management for OAuth 2.0</a>
+     *
+     * @since 4.15
+     */
+    GMResponse gm(GMRequest request, Options options) throws AuthleteApiException;
 
 
     /**
@@ -1849,8 +4043,30 @@ public interface AuthleteApi
      *
      * @since 3.10
      */
+    default void updateClientLockFlag(
+            String clientIdentifier, boolean clientLocked) throws AuthleteApiException
+    {
+        updateClientLockFlag(clientIdentifier, clientLocked, null);
+    }
+
+
+    /**
+     * Update the lock flag of a client application.
+     *
+     * @param clientIdentifier
+     *         The client ID or the client ID alias of a client application.
+     *
+     * @param clientLocked
+     *         The value to which this request updates the lock flag of a client
+     *         application.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @since 4.15
+     */
     void updateClientLockFlag(
-            String clientIdentifier, boolean clientLocked) throws AuthleteApiException;
+            String clientIdentifier, boolean clientLocked, Options options) throws AuthleteApiException;
 
 
     /**
@@ -1865,8 +4081,30 @@ public interface AuthleteApi
      * @since 3.31
      * @since Authlete 2.3
      */
+    default FederationConfigurationResponse federationConfiguration(
+            FederationConfigurationRequest request) throws AuthleteApiException
+    {
+        return federationConfiguration(request, null);
+    }
+
+
+    /**
+     * Call Authlete's {@code /federation/configuration} API.
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     * @since Authlete 2.3
+     */
     FederationConfigurationResponse federationConfiguration(
-            FederationConfigurationRequest request) throws AuthleteApiException;
+            FederationConfigurationRequest request, Options options) throws AuthleteApiException;
 
 
     /**
@@ -1881,8 +4119,30 @@ public interface AuthleteApi
      * @since 3.45
      * @since Authlete 2.3
      */
+    default FederationRegistrationResponse federationRegistration(
+            FederationRegistrationRequest request) throws AuthleteApiException
+    {
+        return federationRegistration(request, null);
+    }
+
+
+    /**
+     * Call Authlete's {@code /federation/registration} API.
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     * @since Authlete 2.3
+     */
     FederationRegistrationResponse federationRegistration(
-            FederationRegistrationRequest request) throws AuthleteApiException;
+            FederationRegistrationRequest request, Options options) throws AuthleteApiException;
 
 
     /**
@@ -1897,8 +4157,30 @@ public interface AuthleteApi
      * @since 3.55
      * @since Authlete 3.0
      */
+    default CredentialIssuerMetadataResponse credentialIssuerMetadata(
+            CredentialIssuerMetadataRequest request) throws AuthleteApiException
+    {
+        return credentialIssuerMetadata(request, null);
+    }
+
+
+    /**
+     * Call Authlete's {@code /vci/metadata} API.
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     * @since Authlete 3.0
+     */
     CredentialIssuerMetadataResponse credentialIssuerMetadata(
-            CredentialIssuerMetadataRequest request) throws AuthleteApiException;
+            CredentialIssuerMetadataRequest request, Options options) throws AuthleteApiException;
 
 
     /**
@@ -1913,8 +4195,30 @@ public interface AuthleteApi
      * @since 3.79
      * @since Authlete 3.0
      */
+    default CredentialJwtIssuerMetadataResponse credentialJwtIssuerMetadata(
+            CredentialJwtIssuerMetadataRequest request) throws AuthleteApiException
+    {
+        return credentialJwtIssuerMetadata(request, null);
+    }
+
+
+    /**
+     * Call Authlete's {@code /vci/jwtissuer} API.
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     * @since Authlete 3.0
+     */
     CredentialJwtIssuerMetadataResponse credentialJwtIssuerMetadata(
-            CredentialJwtIssuerMetadataRequest request) throws AuthleteApiException;
+            CredentialJwtIssuerMetadataRequest request, Options options) throws AuthleteApiException;
 
 
     /**
@@ -1929,8 +4233,30 @@ public interface AuthleteApi
      * @since 3.72
      * @since Authlete 3.0
      */
+    default CredentialIssuerJwksResponse credentialIssuerJwks(
+            CredentialIssuerJwksRequest request) throws AuthleteApiException
+    {
+        return credentialIssuerJwks(request, null);
+    }
+
+
+    /**
+     * Call Authlete's {@code /vci/jwks} API.
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     * @since Authlete 3.0
+     */
     CredentialIssuerJwksResponse credentialIssuerJwks(
-            CredentialIssuerJwksRequest request) throws AuthleteApiException;
+            CredentialIssuerJwksRequest request, Options options) throws AuthleteApiException;
 
 
     /**
@@ -1945,8 +4271,30 @@ public interface AuthleteApi
      * @since 3.59
      * @since Authlete 3.0
      */
+    default CredentialOfferCreateResponse credentialOfferCreate(
+            CredentialOfferCreateRequest request) throws AuthleteApiException
+    {
+        return credentialOfferCreate(request, null);
+    }
+
+
+    /**
+     * Call Authlete's {@code /vci/offer/create} API.
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     * @since Authlete 3.0
+     */
     CredentialOfferCreateResponse credentialOfferCreate(
-            CredentialOfferCreateRequest request) throws AuthleteApiException;
+            CredentialOfferCreateRequest request, Options options) throws AuthleteApiException;
 
 
     /**
@@ -1961,8 +4309,30 @@ public interface AuthleteApi
      * @since 3.59
      * @since Authlete 3.0
      */
+    default CredentialOfferInfoResponse credentialOfferInfo(
+            CredentialOfferInfoRequest request) throws AuthleteApiException
+    {
+        return credentialOfferInfo(request, null);
+    }
+
+
+    /**
+     * Call Authlete's {@code /vci/offer/info} API.
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     * @since Authlete 3.0
+     */
     CredentialOfferInfoResponse credentialOfferInfo(
-            CredentialOfferInfoRequest request) throws AuthleteApiException;
+            CredentialOfferInfoRequest request, Options options) throws AuthleteApiException;
 
 
     /**
@@ -1977,8 +4347,30 @@ public interface AuthleteApi
      * @since 3.66
      * @since Authlete 3.0
      */
+    default CredentialSingleParseResponse credentialSingleParse(
+            CredentialSingleParseRequest request) throws AuthleteApiException
+    {
+        return credentialSingleParse(request, null);
+    }
+
+
+    /**
+     * Call Authlete's {@code /vci/single/parse} API.
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     * @since Authlete 3.0
+     */
     CredentialSingleParseResponse credentialSingleParse(
-            CredentialSingleParseRequest request) throws AuthleteApiException;
+            CredentialSingleParseRequest request, Options options) throws AuthleteApiException;
 
 
     /**
@@ -1993,8 +4385,30 @@ public interface AuthleteApi
      * @since 3.67
      * @since Authlete 3.0
      */
+    default CredentialSingleIssueResponse credentialSingleIssue(
+            CredentialSingleIssueRequest request) throws AuthleteApiException
+    {
+        return credentialSingleIssue(request, null);
+    }
+
+
+    /**
+     * Call Authlete's {@code /vci/single/issue} API.
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     * @since Authlete 3.0
+     */
     CredentialSingleIssueResponse credentialSingleIssue(
-            CredentialSingleIssueRequest request) throws AuthleteApiException;
+            CredentialSingleIssueRequest request, Options options) throws AuthleteApiException;
 
 
     /**
@@ -2009,8 +4423,30 @@ public interface AuthleteApi
      * @since 3.71
      * @since Authlete 3.0
      */
+    default CredentialBatchParseResponse credentialBatchParse(
+            CredentialBatchParseRequest request) throws AuthleteApiException
+    {
+        return credentialBatchParse(request, null);
+    }
+
+
+    /**
+     * Call Authlete's {@code /vci/batch/parse} API.
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     * @since Authlete 3.0
+     */
     CredentialBatchParseResponse credentialBatchParse(
-            CredentialBatchParseRequest request) throws AuthleteApiException;
+            CredentialBatchParseRequest request, Options options) throws AuthleteApiException;
 
 
     /**
@@ -2025,8 +4461,30 @@ public interface AuthleteApi
      * @since 3.71
      * @since Authlete 3.0
      */
+    default CredentialBatchIssueResponse credentialBatchIssue(
+            CredentialBatchIssueRequest request) throws AuthleteApiException
+    {
+        return credentialBatchIssue(request, null);
+    }
+
+
+    /**
+     * Call Authlete's {@code /vci/batch/issue} API.
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     * @since Authlete 3.0
+     */
     CredentialBatchIssueResponse credentialBatchIssue(
-            CredentialBatchIssueRequest request) throws AuthleteApiException;
+            CredentialBatchIssueRequest request, Options options) throws AuthleteApiException;
 
 
     /**
@@ -2041,8 +4499,30 @@ public interface AuthleteApi
      * @since 3.69
      * @since Authlete 3.0
      */
+    default CredentialDeferredParseResponse credentialDeferredParse(
+            CredentialDeferredParseRequest request) throws AuthleteApiException
+    {
+        return credentialDeferredParse(request, null);
+    }
+
+
+    /**
+     * Call Authlete's {@code /vci/deferred/parse} API.
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     * @since Authlete 3.0
+     */
     CredentialDeferredParseResponse credentialDeferredParse(
-            CredentialDeferredParseRequest request) throws AuthleteApiException;
+            CredentialDeferredParseRequest request, Options options) throws AuthleteApiException;
 
 
     /**
@@ -2057,8 +4537,30 @@ public interface AuthleteApi
      * @since 3.70
      * @since Authlete 3.0
      */
+    default CredentialDeferredIssueResponse credentialDeferredIssue(
+            CredentialDeferredIssueRequest request) throws AuthleteApiException
+    {
+        return credentialDeferredIssue(request, null);
+    }
+
+
+    /**
+     * Call Authlete's {@code /vci/deferred/issue} API.
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     * @since Authlete 3.0
+     */
     CredentialDeferredIssueResponse credentialDeferredIssue(
-            CredentialDeferredIssueRequest request) throws AuthleteApiException;
+            CredentialDeferredIssueRequest request, Options options) throws AuthleteApiException;
 
 
     /**
@@ -2074,8 +4576,31 @@ public interface AuthleteApi
      * @since Authlete 2.3.8
      * @since Authlete 3.0
      */
+    default IDTokenReissueResponse idTokenReissue(
+            IDTokenReissueRequest request) throws AuthleteApiException
+    {
+        return idTokenReissue(request, null);
+    }
+
+
+    /**
+     * Call Authlete's {@code /idtoken/reissue} API.
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     * @since Authlete 2.3.8
+     * @since Authlete 3.0
+     */
     IDTokenReissueResponse idTokenReissue(
-            IDTokenReissueRequest request) throws AuthleteApiException;
+            IDTokenReissueRequest request, Options options) throws AuthleteApiException;
 
 
     /**
@@ -2090,8 +4615,30 @@ public interface AuthleteApi
      * @since 3.88
      * @since Authlete 3.0
      */
+    default AuthorizationTicketInfoResponse authorizationTicketInfo(
+            AuthorizationTicketInfoRequest request) throws AuthleteApiException
+    {
+        return authorizationTicketInfo(request, null);
+    }
+
+
+    /**
+     * Call Authlete's {@code /auth/authorization/ticket/info} API.
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     * @since Authlete 3.0
+     */
     AuthorizationTicketInfoResponse authorizationTicketInfo(
-            AuthorizationTicketInfoRequest request) throws AuthleteApiException;
+            AuthorizationTicketInfoRequest request, Options opitons) throws AuthleteApiException;
 
 
     /**
@@ -2106,8 +4653,30 @@ public interface AuthleteApi
      * @since 3.88
      * @since Authlete 3.0
      */
+    default AuthorizationTicketUpdateResponse authorizationTicketUpdate(
+            AuthorizationTicketUpdateRequest request) throws AuthleteApiException
+    {
+        return authorizationTicketUpdate(request, null);
+    }
+
+
+    /**
+     * Call Authlete's {@code /auth/authorization/ticket/update} API.
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     * @since Authlete 3.0
+     */
     AuthorizationTicketUpdateResponse authorizationTicketUpdate(
-            AuthorizationTicketUpdateRequest request) throws AuthleteApiException;
+            AuthorizationTicketUpdateRequest request, Options options) throws AuthleteApiException;
 
 
     /**
@@ -2125,8 +4694,33 @@ public interface AuthleteApi
      * @since 3.96
      * @since Authlete 3.0
      */
+    default TokenCreateBatchResponse tokenCreateBatch(
+            TokenCreateRequest[] request, boolean dryRun) throws AuthleteApiException
+    {
+        return tokenCreateBatch(request, dryRun, null);
+    }
+
+
+    /**
+     * Call Authlete's {@code /auth/token/create/batch} API.
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     *
+     * @param dryRun
+     *         Whether or not to dry-run this API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     * @since Authlete 3.0
+     */
     TokenCreateBatchResponse tokenCreateBatch(
-            TokenCreateRequest[] request, boolean dryRun) throws AuthleteApiException;
+            TokenCreateRequest[] request, boolean dryRun, Options options) throws AuthleteApiException;
 
 
     /**
@@ -2141,6 +4735,28 @@ public interface AuthleteApi
      * @since 3.96
      * @since Authlete 3.0
      */
+    default TokenCreateBatchStatusResponse getTokenCreateBatchStatus(
+            String requestId) throws AuthleteApiException
+    {
+        return getTokenCreateBatchStatus(requestId, null);
+    }
+
+
+    /**
+     * Call Authlete's {@code /auth/token/create/batch/status} API.
+     *
+     * @param requestId
+     *         A request Id issued from {@code /auth/token/create/batch} API.
+     *
+     * @param options
+     *         Request options.
+     *
+     * @return
+     *         Response from the API.
+     *
+     * @since 4.15
+     * @since Authlete 3.0
+     */
     TokenCreateBatchStatusResponse getTokenCreateBatchStatus(
-            String requestId) throws AuthleteApiException;
+            String requestId, Options options) throws AuthleteApiException;
 }

--- a/src/main/java/com/authlete/common/api/AuthleteApiImpl.java
+++ b/src/main/java/com/authlete/common/api/AuthleteApiImpl.java
@@ -29,6 +29,7 @@ import java.net.URLEncoder;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import com.authlete.common.conf.AuthleteConfiguration;
 import com.authlete.common.dto.*;
 import com.authlete.common.types.TokenStatus;
@@ -54,6 +55,14 @@ class AuthleteApiImpl implements AuthleteApi
         GET,
         POST,
         DELETE
+    }
+
+
+    private class HttpHeader
+    {
+        private static final String ACCEPT        = "Accept";
+        private static final String AUTHORIZATION = "Authorization";
+        private static final String CONTENT_TYPE  = "Content-Type";
     }
 
 
@@ -231,9 +240,9 @@ class AuthleteApiImpl implements AuthleteApi
      * Call an API with HTTP GET method and Service Owner credentials (without query parameters).
      */
     private <TResponse> TResponse callServiceOwnerGetApi(
-            String path, Class<TResponse> responseClass) throws AuthleteApiException
+            String path, Class<TResponse> responseClass, Options options) throws AuthleteApiException
     {
-        return callServiceOwnerGetApi(path, (Map<String, String>)null, responseClass);
+        return callServiceOwnerGetApi(path, (Map<String, String>)null, responseClass, options);
     }
 
 
@@ -242,9 +251,9 @@ class AuthleteApiImpl implements AuthleteApi
      */
     private <TResponse> TResponse callServiceOwnerGetApi(
             String path, Map<String, String> queryParams,
-            Class<TResponse> responseClass) throws AuthleteApiException
+            Class<TResponse> responseClass, Options options) throws AuthleteApiException
     {
-        return callGetApi(mServiceOwnerCredentials, path, queryParams, responseClass);
+        return callGetApi(mServiceOwnerCredentials, path, queryParams, responseClass, options);
     }
 
 
@@ -252,9 +261,9 @@ class AuthleteApiImpl implements AuthleteApi
      * Call an API with HTTP GET method and Service credentials (without query parameters).
      */
     private <TResponse> TResponse callServiceGetApi(
-            String path, Class<TResponse> responseClass) throws AuthleteApiException
+            String path, Class<TResponse> responseClass, Options options) throws AuthleteApiException
     {
-        return callServiceGetApi(path, (Map<String, String>)null, responseClass);
+        return callServiceGetApi(path, (Map<String, String>)null, responseClass, options);
     }
 
 
@@ -263,9 +272,9 @@ class AuthleteApiImpl implements AuthleteApi
      */
     private <TResponse> TResponse callServiceGetApi(
             String path, Map<String, String> queryParams,
-            Class<TResponse> responseClass) throws AuthleteApiException
+            Class<TResponse> responseClass, Options options) throws AuthleteApiException
     {
-        return callGetApi(mServiceCredentials, path, queryParams, responseClass);
+        return callGetApi(mServiceCredentials, path, queryParams, responseClass, options);
     }
 
 
@@ -274,9 +283,9 @@ class AuthleteApiImpl implements AuthleteApi
      */
     private <TResponse> TResponse callGetApi(
             BasicCredentials credentials, String path, Map<String, String> queryParams,
-            Class<TResponse> responseClass) throws AuthleteApiException
+            Class<TResponse> responseClass, Options options) throws AuthleteApiException
     {
-        return callApi(HttpMethod.GET, credentials, path, queryParams, (Object)null, responseClass);
+        return callApi(HttpMethod.GET, credentials, path, queryParams, (Object)null, responseClass, options);
     }
 
 
@@ -284,9 +293,9 @@ class AuthleteApiImpl implements AuthleteApi
      * Call an API with HTTP POST method and Service Owner credentials (without query parameters).
      */
     private <TResponse> TResponse callServiceOwnerPostApi(
-            String path, Object requestBody, Class<TResponse> responseClass) throws AuthleteApiException
+            String path, Object requestBody, Class<TResponse> responseClass, Options options) throws AuthleteApiException
     {
-        return callServiceOwnerPostApi(path, (Map<String, String>)null, requestBody, responseClass);
+        return callServiceOwnerPostApi(path, (Map<String, String>)null, requestBody, responseClass, options);
     }
 
 
@@ -295,9 +304,9 @@ class AuthleteApiImpl implements AuthleteApi
      */
     private <TResponse> TResponse callServiceOwnerPostApi(
             String path, Map<String, String> queryParams,
-            Object requestBody, Class<TResponse> responseClass) throws AuthleteApiException
+            Object requestBody, Class<TResponse> responseClass, Options options) throws AuthleteApiException
     {
-        return callPostApi(mServiceOwnerCredentials, path, queryParams, requestBody, responseClass);
+        return callPostApi(mServiceOwnerCredentials, path, queryParams, requestBody, responseClass, options);
     }
 
 
@@ -305,9 +314,9 @@ class AuthleteApiImpl implements AuthleteApi
      * Call an API with HTTP POST method and Service credentials (without query parameters).
      */
     private <TResponse> TResponse callServicePostApi(
-            String path, Object requestBody, Class<TResponse> responseClass) throws AuthleteApiException
+            String path, Object requestBody, Class<TResponse> responseClass, Options options) throws AuthleteApiException
     {
-        return callServicePostApi(path, (Map<String, String>)null, requestBody, responseClass);
+        return callServicePostApi(path, (Map<String, String>)null, requestBody, responseClass, options);
     }
 
 
@@ -316,9 +325,9 @@ class AuthleteApiImpl implements AuthleteApi
      */
     private <TResponse> TResponse callServicePostApi(
             String path, Map<String, String> queryParams,
-            Object requestBody, Class<TResponse> responseClass) throws AuthleteApiException
+            Object requestBody, Class<TResponse> responseClass, Options options) throws AuthleteApiException
     {
-        return callPostApi(mServiceCredentials, path, queryParams, requestBody, responseClass);
+        return callPostApi(mServiceCredentials, path, queryParams, requestBody, responseClass, options);
     }
 
 
@@ -327,18 +336,18 @@ class AuthleteApiImpl implements AuthleteApi
      */
     private <TResponse> TResponse callPostApi(
             BasicCredentials credentials, String path, Map<String, String> queryParams,
-            Object requestBody, Class<TResponse> responseClass) throws AuthleteApiException
+            Object requestBody, Class<TResponse> responseClass, Options options) throws AuthleteApiException
     {
-        return callApi(HttpMethod.POST, credentials, path, queryParams, requestBody, responseClass);
+        return callApi(HttpMethod.POST, credentials, path, queryParams, requestBody, responseClass, options);
     }
 
 
     /**
      * Call an API with HTTP DELETE method and Service Owner credentials (without query parameters).
      */
-    private <TResponse> void callServiceOwnerDeleteApi(String path) throws AuthleteApiException
+    private <TResponse> void callServiceOwnerDeleteApi(String path, Options options) throws AuthleteApiException
     {
-        callServiceOwnerDeleteApi(path, (Map<String, String>)null);
+        callServiceOwnerDeleteApi(path, (Map<String, String>)null, options);
     }
 
 
@@ -346,18 +355,18 @@ class AuthleteApiImpl implements AuthleteApi
      * Call an API with HTTP DELETE method and Service Owner credentials.
      */
     private <TResponse> void callServiceOwnerDeleteApi(
-            String path, Map<String, String> queryParams) throws AuthleteApiException
+            String path, Map<String, String> queryParams, Options options) throws AuthleteApiException
     {
-        callDeleteApi(mServiceOwnerCredentials, path, queryParams);
+        callDeleteApi(mServiceOwnerCredentials, path, queryParams, options);
     }
 
 
     /**
      * Call an API with HTTP DELETE method and Service credentials (without query parameters).
      */
-    private <TResponse> void callServiceDeleteApi(String path) throws AuthleteApiException
+    private <TResponse> void callServiceDeleteApi(String path, Options options) throws AuthleteApiException
     {
-        callServiceDeleteApi(path, (Map<String, String>)null);
+        callServiceDeleteApi(path, (Map<String, String>)null, options);
     }
 
 
@@ -365,9 +374,9 @@ class AuthleteApiImpl implements AuthleteApi
      * Call an API with HTTP DELETE method and Service credentials.
      */
     private <TResponse> void callServiceDeleteApi(
-            String path, Map<String, String> queryParams) throws AuthleteApiException
+            String path, Map<String, String> queryParams, Options options) throws AuthleteApiException
     {
-        callDeleteApi(mServiceCredentials, path, queryParams);
+        callDeleteApi(mServiceCredentials, path, queryParams, options);
     }
 
 
@@ -376,9 +385,9 @@ class AuthleteApiImpl implements AuthleteApi
      */
     private <TResponse> void callDeleteApi(
             BasicCredentials credentials, String path,
-            Map<String, String> queryParams) throws AuthleteApiException
+            Map<String, String> queryParams, Options options) throws AuthleteApiException
     {
-        callApi(HttpMethod.DELETE, credentials, path, queryParams, (Object)null, (Class<TResponse>)null);
+        callApi(HttpMethod.DELETE, credentials, path, queryParams, (Object)null, (Class<TResponse>)null, options);
     }
 
 
@@ -388,11 +397,11 @@ class AuthleteApiImpl implements AuthleteApi
     private <TResponse> TResponse callApi(
             HttpMethod method, BasicCredentials credentials,
             String path, Map<String, String> queryParams,
-            Object requestBody, Class<TResponse> responseClass) throws AuthleteApiException
+            Object requestBody, Class<TResponse> responseClass, Options options) throws AuthleteApiException
     {
         // Create a connection to the Authlete API.
         ConnectionContext ctx = createConnection(
-                method, credentials, mBaseUrl, path, queryParams, mSettings);
+                method, credentials, mBaseUrl, path, queryParams, options, mSettings);
 
         try
         {
@@ -409,14 +418,14 @@ class AuthleteApiImpl implements AuthleteApi
 
     private static ConnectionContext createConnection(
             HttpMethod method, BasicCredentials credentials,
-            String baseUrl, String path, Map<String, String> queryParams,
+            String baseUrl, String path, Map<String, String> queryParams, Options options,
             Settings settings) throws AuthleteApiException
     {
         try
         {
             // Open a connection to the Authlete API.
             return openConnection(
-                    method, credentials, baseUrl, path, queryParams, settings);
+                    method, credentials, baseUrl, path, queryParams, options, settings);
         }
         catch (Throwable cause)
         {
@@ -428,7 +437,7 @@ class AuthleteApiImpl implements AuthleteApi
 
     private static ConnectionContext openConnection(
             HttpMethod method, BasicCredentials credentials, String baseUrl,
-            String path, Map<String, String> queryParams,
+            String path, Map<String, String> queryParams, Options options,
             Settings settings) throws IOException
     {
         // URL of an Authlete API.
@@ -443,11 +452,14 @@ class AuthleteApiImpl implements AuthleteApi
         if (credentials != null)
         {
             // Set 'Authorization' HTTP header to access the Authlete API.
-            con.setRequestProperty("Authorization", credentials.format());
+            con.setRequestProperty(HttpHeader.AUTHORIZATION, credentials.format());
         }
 
         // Set 'Accept' HTTP header for a JSON response.
-        con.setRequestProperty("Accept", "application/json");
+        con.setRequestProperty(HttpHeader.ACCEPT, "application/json");
+
+        // Set custom request headers if needed.
+        setCustomRequestHeaders(con, options);
 
         // Expect a response body.
         con.setDoInput(true);
@@ -545,6 +557,40 @@ class AuthleteApiImpl implements AuthleteApi
     }
 
 
+    private static void setCustomRequestHeaders(HttpURLConnection con, Options options)
+    {
+        // Custom headers.
+        Map<String, String> headers = options.getHeaders();
+
+        if (headers == null)
+        {
+            return;
+        }
+
+        for (Entry<String, String> e : headers.entrySet())
+        {
+            // The key of the header.
+            String key = e.getKey();
+
+            // Some header keys are reserved.
+            if (isReservedRequestHeader(key))
+            {
+                continue;
+            }
+
+            con.setRequestProperty(key, e.getValue());
+        }
+    }
+
+
+    private static boolean isReservedRequestHeader(String key)
+    {
+        return key.equals(HttpHeader.ACCEPT) ||
+               key.equals(HttpHeader.AUTHORIZATION) ||
+               key.equals(HttpHeader.CONTENT_TYPE);
+    }
+
+
     @SuppressWarnings("unchecked")
     private <TResponse> TResponse communicate(
             ConnectionContext ctx, Object requestBody, Class<TResponse> responseClass) throws AuthleteApiException
@@ -580,7 +626,7 @@ class AuthleteApiImpl implements AuthleteApi
     private static void writeRequestBody(ConnectionContext ctx, Object requestBody) throws AuthleteApiException
     {
         // Set 'Content-Type' to send JSON.
-        ctx.property("Content-Type", "application/json");
+        ctx.property(HttpHeader.CONTENT_TYPE, "application/json");
 
         // Use the connection as an output stream.
         ctx.doOutput(true);
@@ -830,201 +876,201 @@ class AuthleteApiImpl implements AuthleteApi
 
 
     @Override
-    public AuthorizationResponse authorization(AuthorizationRequest request) throws AuthleteApiException
+    public AuthorizationResponse authorization(AuthorizationRequest request, Options options) throws AuthleteApiException
     {
         return callServicePostApi(
-                AUTH_AUTHORIZATION_API_PATH, request, AuthorizationResponse.class);
+                AUTH_AUTHORIZATION_API_PATH, request, AuthorizationResponse.class, options);
     }
 
 
     @Override
-    public AuthorizationFailResponse authorizationFail(AuthorizationFailRequest request) throws AuthleteApiException
+    public AuthorizationFailResponse authorizationFail(AuthorizationFailRequest request, Options options) throws AuthleteApiException
     {
         return callServicePostApi(
-                AUTH_AUTHORIZATION_FAIL_API_PATH, request, AuthorizationFailResponse.class);
+                AUTH_AUTHORIZATION_FAIL_API_PATH, request, AuthorizationFailResponse.class, options);
     }
 
 
     @Override
-    public AuthorizationIssueResponse authorizationIssue(AuthorizationIssueRequest request) throws AuthleteApiException
+    public AuthorizationIssueResponse authorizationIssue(AuthorizationIssueRequest request, Options options) throws AuthleteApiException
     {
         return callServicePostApi(
-                AUTH_AUTHORIZATION_ISSUE_API_PATH, request, AuthorizationIssueResponse.class);
+                AUTH_AUTHORIZATION_ISSUE_API_PATH, request, AuthorizationIssueResponse.class, options);
     }
 
 
     @Override
-    public TokenResponse token(TokenRequest request) throws AuthleteApiException
+    public TokenResponse token(TokenRequest request, Options options) throws AuthleteApiException
     {
         return callServicePostApi(
-                AUTH_TOKEN_API_PATH, request, TokenResponse.class);
+                AUTH_TOKEN_API_PATH, request, TokenResponse.class, options);
     }
 
 
     @Override
-    public TokenCreateResponse tokenCreate(TokenCreateRequest request) throws AuthleteApiException
+    public TokenCreateResponse tokenCreate(TokenCreateRequest request, Options options) throws AuthleteApiException
     {
         return callServicePostApi(
-                AUTH_TOKEN_CREATE_API_PATH, request, TokenCreateResponse.class);
+                AUTH_TOKEN_CREATE_API_PATH, request, TokenCreateResponse.class, options);
     }
 
 
     @Override
-    public void tokenDelete(String token) throws AuthleteApiException
+    public void tokenDelete(String token, Options options) throws AuthleteApiException
     {
         callServiceDeleteApi(
-                String.format(AUTH_TOKEN_DELETE_API_PATH, token));
+                String.format(AUTH_TOKEN_DELETE_API_PATH, token), options);
     }
 
 
     @Override
-    public TokenFailResponse tokenFail(TokenFailRequest request) throws AuthleteApiException
+    public TokenFailResponse tokenFail(TokenFailRequest request, Options options) throws AuthleteApiException
     {
         return callServicePostApi(
-                AUTH_TOKEN_FAIL_API_PATH, request, TokenFailResponse.class);
+                AUTH_TOKEN_FAIL_API_PATH, request, TokenFailResponse.class, options);
     }
 
 
     @Override
-    public TokenIssueResponse tokenIssue(TokenIssueRequest request) throws AuthleteApiException
+    public TokenIssueResponse tokenIssue(TokenIssueRequest request, Options options) throws AuthleteApiException
     {
         return callServicePostApi(
-                AUTH_TOKEN_ISSUE_API_PATH, request, TokenIssueResponse.class);
+                AUTH_TOKEN_ISSUE_API_PATH, request, TokenIssueResponse.class, options);
     }
 
 
     @Override
-    public TokenRevokeResponse tokenRevoke(TokenRevokeRequest request) throws AuthleteApiException
+    public TokenRevokeResponse tokenRevoke(TokenRevokeRequest request, Options options) throws AuthleteApiException
     {
         return callServicePostApi(
-                AUTH_TOKEN_REVOKE_API_PATH, request, TokenRevokeResponse.class);
+                AUTH_TOKEN_REVOKE_API_PATH, request, TokenRevokeResponse.class, options);
     }
 
 
     @Override
-    public TokenUpdateResponse tokenUpdate(TokenUpdateRequest request) throws AuthleteApiException
+    public TokenUpdateResponse tokenUpdate(TokenUpdateRequest request, Options options) throws AuthleteApiException
     {
         return callServicePostApi(
-                AUTH_TOKEN_UPDATE_API_PATH, request, TokenUpdateResponse.class);
+                AUTH_TOKEN_UPDATE_API_PATH, request, TokenUpdateResponse.class, options);
     }
 
 
     @Override
-    public TokenListResponse getTokenList() throws AuthleteApiException
+    public TokenListResponse getTokenList(Options options) throws AuthleteApiException
     {
-        return getTokenList(TokenStatus.ALL);
+        return getTokenList(TokenStatus.ALL, options);
     }
 
 
     @Override
-    public TokenListResponse getTokenList(TokenStatus tokenStatus) throws AuthleteApiException
+    public TokenListResponse getTokenList(TokenStatus tokenStatus, Options options) throws AuthleteApiException
     {
         return callServiceGetApi(
                 AUTH_TOKEN_GET_LIST_API_PATH,
                 buildMap("tokenStatus", tokenStatus),
-                TokenListResponse.class);
+                TokenListResponse.class, options);
     }
 
 
     @Override
-    public TokenListResponse getTokenList(String clientIdentifier, String subject) throws AuthleteApiException
+    public TokenListResponse getTokenList(String clientIdentifier, String subject, Options options) throws AuthleteApiException
     {
-        return getTokenList(clientIdentifier, subject, TokenStatus.ALL);
+        return getTokenList(clientIdentifier, subject, TokenStatus.ALL, options);
     }
 
 
     @Override
-    public TokenListResponse getTokenList(String clientIdentifier, String subject, TokenStatus tokenStatus) throws AuthleteApiException
+    public TokenListResponse getTokenList(String clientIdentifier, String subject, TokenStatus tokenStatus, Options options) throws AuthleteApiException
     {
         return callServiceGetApi(
                 AUTH_TOKEN_GET_LIST_API_PATH,
                 buildMap("clientIdentifier", clientIdentifier, "subject", subject, "tokenStatus", tokenStatus),
-                TokenListResponse.class);
+                TokenListResponse.class, options);
     }
 
 
     @Override
-    public TokenListResponse getTokenList(int start, int end) throws AuthleteApiException
+    public TokenListResponse getTokenList(int start, int end, Options options) throws AuthleteApiException
     {
-        return getTokenList(start, end, TokenStatus.ALL);
+        return getTokenList(start, end, TokenStatus.ALL, options);
     }
 
 
     @Override
-    public TokenListResponse getTokenList(int start, int end, TokenStatus tokenStatus) throws AuthleteApiException
+    public TokenListResponse getTokenList(int start, int end, TokenStatus tokenStatus, Options options) throws AuthleteApiException
     {
         return callServiceGetApi(
                 AUTH_TOKEN_GET_LIST_API_PATH,
                 buildMap("start", start, "end", end, "tokenStatus", tokenStatus),
-                TokenListResponse.class);
+                TokenListResponse.class, options);
     }
 
 
     @Override
     public TokenListResponse getTokenList(String clientIdentifier, String subject,
-                                          int start, int end) throws AuthleteApiException
+                                          int start, int end, Options options) throws AuthleteApiException
     {
-        return getTokenList(clientIdentifier, subject, start, end, TokenStatus.ALL);
+        return getTokenList(clientIdentifier, subject, start, end, TokenStatus.ALL, options);
     }
 
 
     @Override
     public TokenListResponse getTokenList(String clientIdentifier, String subject,
-            int start, int end, TokenStatus tokenStatus) throws AuthleteApiException
+            int start, int end, TokenStatus tokenStatus, Options options) throws AuthleteApiException
     {
         return callServiceGetApi(
                 AUTH_TOKEN_GET_LIST_API_PATH,
                 buildMap("clientIdentifier", clientIdentifier, "subject", subject, "start", start, "end", end, "tokenStatus", tokenStatus),
-                TokenListResponse.class);
+                TokenListResponse.class, options);
     }
 
 
     @Override
-    public RevocationResponse revocation(RevocationRequest request) throws AuthleteApiException
+    public RevocationResponse revocation(RevocationRequest request, Options options) throws AuthleteApiException
     {
         return callServicePostApi(
-                AUTH_REVOCATION_API_PATH, request, RevocationResponse.class);
+                AUTH_REVOCATION_API_PATH, request, RevocationResponse.class, options);
     }
 
 
     @Override
-    public UserInfoResponse userinfo(UserInfoRequest request) throws AuthleteApiException
+    public UserInfoResponse userinfo(UserInfoRequest request, Options options) throws AuthleteApiException
     {
         return callServicePostApi(
-                AUTH_USERINFO_API_PATH, request, UserInfoResponse.class);
+                AUTH_USERINFO_API_PATH, request, UserInfoResponse.class, options);
     }
 
 
     @Override
-    public UserInfoIssueResponse userinfoIssue(UserInfoIssueRequest request) throws AuthleteApiException
+    public UserInfoIssueResponse userinfoIssue(UserInfoIssueRequest request, Options options) throws AuthleteApiException
     {
         return callServicePostApi(
-                AUTH_USERINFO_ISSUE_API_PATH, request, UserInfoIssueResponse.class);
+                AUTH_USERINFO_ISSUE_API_PATH, request, UserInfoIssueResponse.class, options);
     }
 
 
     @Override
-    public IntrospectionResponse introspection(IntrospectionRequest request) throws AuthleteApiException
+    public IntrospectionResponse introspection(IntrospectionRequest request, Options options) throws AuthleteApiException
     {
         return callServicePostApi(
-                AUTH_INTROSPECTION_API_PATH, request, IntrospectionResponse.class);
+                AUTH_INTROSPECTION_API_PATH, request, IntrospectionResponse.class, options);
     }
 
 
     @Override
     public StandardIntrospectionResponse standardIntrospection(
-            StandardIntrospectionRequest request) throws AuthleteApiException
+            StandardIntrospectionRequest request, Options options) throws AuthleteApiException
     {
         return callServicePostApi(
-                AUTH_INTROSPECTION_STANDARD_API_PATH, request, StandardIntrospectionResponse.class);
+                AUTH_INTROSPECTION_STANDARD_API_PATH, request, StandardIntrospectionResponse.class, options);
     }
 
 
     @Override
-    public Service createService(Service service) throws AuthleteApiException
+    public Service createService(Service service, Options options) throws AuthleteApiException
     {
         return callServiceOwnerPostApi(
-                SERVICE_CREATE_API_PATH, service, Service.class);
+                SERVICE_CREATE_API_PATH, service, Service.class, options);
     }
 
 
@@ -1036,220 +1082,220 @@ class AuthleteApiImpl implements AuthleteApi
 
 
     @Override
-    public void deleteService(long apiKey) throws AuthleteApiException
+    public void deleteService(long apiKey, Options options) throws AuthleteApiException
     {
         callServiceOwnerDeleteApi(
-                String.format(SERVICE_DELETE_API_PATH, apiKey));
+                String.format(SERVICE_DELETE_API_PATH, apiKey), options);
     }
 
 
     @Override
-    public Service getService(long apiKey) throws AuthleteApiException
+    public Service getService(long apiKey, Options options) throws AuthleteApiException
     {
         return callServiceOwnerGetApi(
-                String.format(SERVICE_GET_API_PATH, apiKey), Service.class);
+                String.format(SERVICE_GET_API_PATH, apiKey), Service.class, options);
     }
 
 
     @Override
-    public ServiceListResponse getServiceList() throws AuthleteApiException
+    public ServiceListResponse getServiceList(Options options) throws AuthleteApiException
     {
         return callServiceOwnerGetApi(
-                SERVICE_GET_LIST_API_PATH, ServiceListResponse.class);
+                SERVICE_GET_LIST_API_PATH, ServiceListResponse.class, options);
     }
 
 
     @Override
-    public ServiceListResponse getServiceList(int start, int end) throws AuthleteApiException
+    public ServiceListResponse getServiceList(int start, int end, Options options) throws AuthleteApiException
     {
         return callServiceOwnerGetApi(
                 SERVICE_GET_LIST_API_PATH,
                 buildMap("start", start, "end", end),
-                ServiceListResponse.class);
+                ServiceListResponse.class, options);
     }
 
 
     @Override
-    public Service updateService(Service service) throws AuthleteApiException
+    public Service updateService(Service service, Options options) throws AuthleteApiException
     {
         return callServiceOwnerPostApi(
                 String.format(SERVICE_UPDATE_API_PATH, service.getApiKey()),
-                service, Service.class);
+                service, Service.class, options);
     }
 
 
     @Override
-    public String getServiceJwks() throws AuthleteApiException
+    public String getServiceJwks(Options options) throws AuthleteApiException
     {
         return callServiceGetApi(
-                SERVICE_JWKS_GET_API_PATH, String.class);
+                SERVICE_JWKS_GET_API_PATH, String.class, options);
     }
 
 
     @Override
-    public String getServiceJwks(boolean pretty, boolean includePrivateKeys) throws AuthleteApiException
+    public String getServiceJwks(boolean pretty, boolean includePrivateKeys, Options options) throws AuthleteApiException
     {
         return callServiceGetApi(
                 SERVICE_JWKS_GET_API_PATH,
                 buildMap("pretty", pretty, "includePrivateKeys", includePrivateKeys),
-                String.class);
+                String.class, options);
     }
 
 
     @Override
-    public String getServiceConfiguration() throws AuthleteApiException
+    public String getServiceConfiguration(Options options) throws AuthleteApiException
     {
         return callServiceGetApi(
-                SERVICE_CONFIGURATION_API_PATH, String.class);
+                SERVICE_CONFIGURATION_API_PATH, String.class, options);
     }
 
 
     @Override
-    public String getServiceConfiguration(boolean pretty) throws AuthleteApiException
+    public String getServiceConfiguration(boolean pretty, Options options) throws AuthleteApiException
     {
         return callServiceGetApi(
                 SERVICE_CONFIGURATION_API_PATH,
                 buildMap("pretty", pretty),
-                String.class);
+                String.class, options);
     }
 
 
     @Override
-    public String getServiceConfiguration(ServiceConfigurationRequest request) throws AuthleteApiException
+    public String getServiceConfiguration(ServiceConfigurationRequest request, Options options) throws AuthleteApiException
     {
         return callServicePostApi(
-                SERVICE_CONFIGURATION_API_PATH, request, String.class);
+                SERVICE_CONFIGURATION_API_PATH, request, String.class, options);
     }
 
 
     @Override
-    public Client createClient(Client client) throws AuthleteApiException
+    public Client createClient(Client client, Options options) throws AuthleteApiException
     {
         return callServicePostApi(
-                CLIENT_CREATE_API_PATH, client, Client.class);
+                CLIENT_CREATE_API_PATH, client, Client.class, options);
     }
 
 
     @Override
     public ClientRegistrationResponse dynamicClientRegister(
-            ClientRegistrationRequest request) throws AuthleteApiException
+            ClientRegistrationRequest request, Options options) throws AuthleteApiException
     {
         return callServicePostApi(
-                CLIENT_REGISTRATION_API_PATH, request, ClientRegistrationResponse.class);
+                CLIENT_REGISTRATION_API_PATH, request, ClientRegistrationResponse.class, options);
     }
 
 
     @Override
     public ClientRegistrationResponse dynamicClientGet(
-            ClientRegistrationRequest request)
+            ClientRegistrationRequest request, Options options)
     {
         return callServicePostApi(
-                CLIENT_REGISTRATION_GET_API_PATH, request, ClientRegistrationResponse.class);
+                CLIENT_REGISTRATION_GET_API_PATH, request, ClientRegistrationResponse.class, options);
     }
 
 
     @Override
     public ClientRegistrationResponse dynamicClientUpdate(
-            ClientRegistrationRequest request)
+            ClientRegistrationRequest request, Options options)
     {
         return callServicePostApi(
-                CLIENT_REGISTRATION_UPDATE_API_PATH, request, ClientRegistrationResponse.class);
+                CLIENT_REGISTRATION_UPDATE_API_PATH, request, ClientRegistrationResponse.class, options);
     }
 
 
     @Override
     public ClientRegistrationResponse dynamicClientDelete(
-            ClientRegistrationRequest request)
+            ClientRegistrationRequest request, Options options)
     {
         return callServicePostApi(
-                CLIENT_REGISTRATION_DELETE_API_PATH, request, ClientRegistrationResponse.class);
+                CLIENT_REGISTRATION_DELETE_API_PATH, request, ClientRegistrationResponse.class, options);
     }
 
 
     @Override
-    public void deleteClient(long clientId) throws AuthleteApiException
+    public void deleteClient(long clientId, Options options) throws AuthleteApiException
     {
-        deleteClient(String.valueOf(clientId));
+        deleteClient(String.valueOf(clientId), options);
     }
 
 
     @Override
-    public void deleteClient(String clientId) throws AuthleteApiException
+    public void deleteClient(String clientId, Options options) throws AuthleteApiException
     {
         callServiceDeleteApi(
-                String.format(CLIENT_DELETE_API_PATH, clientId));
+                String.format(CLIENT_DELETE_API_PATH, clientId), options);
     }
 
 
     @Override
-    public Client getClient(long clientId) throws AuthleteApiException
+    public Client getClient(long clientId, Options options) throws AuthleteApiException
     {
-        return getClient(String.valueOf(clientId));
+        return getClient(String.valueOf(clientId), options);
     }
 
 
     @Override
-    public Client getClient(String clientId) throws AuthleteApiException
-    {
-        return callServiceGetApi(
-                String.format(CLIENT_GET_API_PATH, clientId), Client.class);
-    }
-
-
-    @Override
-    public ClientListResponse getClientList() throws AuthleteApiException
+    public Client getClient(String clientId, Options options) throws AuthleteApiException
     {
         return callServiceGetApi(
-                CLIENT_GET_LIST_API_PATH, ClientListResponse.class);
+                String.format(CLIENT_GET_API_PATH, clientId), Client.class, options);
     }
 
 
     @Override
-    public ClientListResponse getClientList(String developer) throws AuthleteApiException
+    public ClientListResponse getClientList(Options options) throws AuthleteApiException
+    {
+        return callServiceGetApi(
+                CLIENT_GET_LIST_API_PATH, ClientListResponse.class, options);
+    }
+
+
+    @Override
+    public ClientListResponse getClientList(String developer, Options options) throws AuthleteApiException
     {
         return callServiceGetApi(
                 CLIENT_GET_LIST_API_PATH,
                 buildMap("developer", developer),
-                ClientListResponse.class);
+                ClientListResponse.class, options);
     }
 
 
     @Override
-    public ClientListResponse getClientList(int start, int end) throws AuthleteApiException
+    public ClientListResponse getClientList(int start, int end, Options options) throws AuthleteApiException
     {
         return callServiceGetApi(
                 CLIENT_GET_LIST_API_PATH,
                 buildMap("start", start, "end", end),
-                ClientListResponse.class);
+                ClientListResponse.class, options);
     }
 
 
     @Override
-    public ClientListResponse getClientList(String developer, int start, int end) throws AuthleteApiException
+    public ClientListResponse getClientList(String developer, int start, int end, Options options) throws AuthleteApiException
     {
         return callServiceGetApi(
                 CLIENT_GET_LIST_API_PATH,
                 buildMap("developer", developer, "start", start, "end", end),
-                ClientListResponse.class);
+                ClientListResponse.class, options);
     }
 
 
     @Override
-    public Client updateClient(Client client) throws AuthleteApiException
+    public Client updateClient(Client client, Options options) throws AuthleteApiException
     {
         return callServicePostApi(
                 String.format(CLIENT_UPDATE_API_PATH, client.getClientId()),
-                client, Client.class);
+                client, Client.class, options);
     }
 
 
     @Override
-    public String[] getRequestableScopes(long clientId) throws AuthleteApiException
+    public String[] getRequestableScopes(long clientId, Options options) throws AuthleteApiException
     {
         // Call the API.
         RequestableScopes response = callServiceGetApi(
                 String.format(REQUESTABLE_SCOPES_GET_API_PATH, clientId),
-                RequestableScopes.class);
+                RequestableScopes.class, options);
 
         // Extract 'requestableScopes' from the response.
         return extractRequestableScopes(response);
@@ -1257,7 +1303,7 @@ class AuthleteApiImpl implements AuthleteApi
 
 
     @Override
-    public String[] setRequestableScopes(long clientId, String[] scopes) throws AuthleteApiException
+    public String[] setRequestableScopes(long clientId, String[] scopes, Options options) throws AuthleteApiException
     {
         // Prepare a request body.
         RequestableScopes request = new RequestableScopes(scopes);
@@ -1265,7 +1311,7 @@ class AuthleteApiImpl implements AuthleteApi
         // Call the API.
         RequestableScopes response = callServicePostApi(
                 String.format(REQUESTABLE_SCOPES_UPDATE_API_PATH, clientId),
-                request, RequestableScopes.class);
+                request, RequestableScopes.class, options);
 
         // Extract 'requestableScopes' from the response.
         return extractRequestableScopes(response);
@@ -1273,10 +1319,10 @@ class AuthleteApiImpl implements AuthleteApi
 
 
     @Override
-    public void deleteRequestableScopes(long clientId) throws AuthleteApiException
+    public void deleteRequestableScopes(long clientId, Options options) throws AuthleteApiException
     {
         callServiceDeleteApi(
-                String.format(REQUESTABLE_SCOPES_DELETE_API_PATH, clientId));
+                String.format(REQUESTABLE_SCOPES_DELETE_API_PATH, clientId), options);
     }
 
 
@@ -1294,26 +1340,26 @@ class AuthleteApiImpl implements AuthleteApi
 
 
     @Override
-    public GrantedScopesGetResponse getGrantedScopes(long clientId, String subject)
+    public GrantedScopesGetResponse getGrantedScopes(long clientId, String subject, Options options)
     {
         // Prepare a request body.
         GrantedScopesRequest request = new GrantedScopesRequest(subject);
 
         return callServicePostApi(
                 String.format(GRANTED_SCOPES_GET_API_PATH, clientId),
-                request, GrantedScopesGetResponse.class);
+                request, GrantedScopesGetResponse.class, options);
     }
 
 
     @Override
-    public void deleteGrantedScopes(long clientId, String subject)
+    public void deleteGrantedScopes(long clientId, String subject, Options options)
     {
         // Prepare a request body.
         GrantedScopesRequest request = new GrantedScopesRequest(subject);
 
         callServicePostApi(
                 String.format(GRANTED_SCOPES_DELETE_API_PATH, clientId),
-                request, ApiResponse.class);
+                request, ApiResponse.class, options);
     }
 
 
@@ -1375,64 +1421,66 @@ class AuthleteApiImpl implements AuthleteApi
 
 
     @Override
-    public void deleteClientAuthorization(long clientId, String subject) throws AuthleteApiException
+    public void deleteClientAuthorization(long clientId, String subject, Options options) throws AuthleteApiException
     {
         // Prepare a request body.
         ClientAuthorizationDeleteRequest request = new ClientAuthorizationDeleteRequest(subject);
 
         callServicePostApi(
                 String.format(CLIENT_AUTHORIZATION_DELETE_API_PATH, clientId),
-                request, ApiResponse.class);
+                request, ApiResponse.class, options);
     }
 
 
     @Override
-    public AuthorizedClientListResponse getClientAuthorizationList(ClientAuthorizationGetListRequest request) throws AuthleteApiException
+    public AuthorizedClientListResponse getClientAuthorizationList(
+            ClientAuthorizationGetListRequest request, Options options) throws AuthleteApiException
     {
         return callServicePostApi(
                 CLIENT_AUTHORIZATION_GET_LIST_API_PATH,
-                request, AuthorizedClientListResponse.class);
+                request, AuthorizedClientListResponse.class, options);
     }
 
 
     @Override
-    public void updateClientAuthorization(long clientId, ClientAuthorizationUpdateRequest request) throws AuthleteApiException
+    public void updateClientAuthorization(
+            long clientId, ClientAuthorizationUpdateRequest request, Options options) throws AuthleteApiException
     {
         callServicePostApi(
                 String.format(CLIENT_AUTHORIZATION_UPDATE_API_PATH, clientId),
-                request, ApiResponse.class);
+                request, ApiResponse.class, options);
     }
 
 
     @Override
     public ClientSecretRefreshResponse refreshClientSecret(
-            long clientId) throws AuthleteApiException
+            long clientId, Options options) throws AuthleteApiException
     {
-        return refreshClientSecret(String.valueOf(clientId));
+        return refreshClientSecret(String.valueOf(clientId), options);
     }
 
 
     @Override
     public ClientSecretRefreshResponse refreshClientSecret(
-            String clientIdentifier) throws AuthleteApiException
+            String clientIdentifier, Options options) throws AuthleteApiException
     {
         return callServiceGetApi(
                 String.format(CLIENT_SECRET_REFRESH_API_PATH, clientIdentifier),
-                ClientSecretRefreshResponse.class);
+                ClientSecretRefreshResponse.class, options);
     }
 
 
     @Override
     public ClientSecretUpdateResponse updateClientSecret(
-            long clientId, String clientSecret) throws AuthleteApiException
+            long clientId, String clientSecret, Options options) throws AuthleteApiException
     {
-        return updateClientSecret(String.valueOf(clientId), clientSecret);
+        return updateClientSecret(String.valueOf(clientId), clientSecret, options);
     }
 
 
     @Override
     public ClientSecretUpdateResponse updateClientSecret(
-            String clientIdentifier, String clientSecret) throws AuthleteApiException
+            String clientIdentifier, String clientSecret, Options options) throws AuthleteApiException
     {
         // Prepare a request body. setClientSecret(String) method
         // throws IllegalArgumentException if the given client secret
@@ -1442,7 +1490,7 @@ class AuthleteApiImpl implements AuthleteApi
 
         return callServicePostApi(
                 String.format(CLIENT_SECRET_UPDATE_API_PATH, clientIdentifier),
-                request, ClientSecretUpdateResponse.class);
+                request, ClientSecretUpdateResponse.class, options);
     }
 
 
@@ -1454,149 +1502,150 @@ class AuthleteApiImpl implements AuthleteApi
 
 
     @Override
-    public JoseVerifyResponse verifyJose(JoseVerifyRequest request) throws AuthleteApiException
+    public JoseVerifyResponse verifyJose(JoseVerifyRequest request, Options options) throws AuthleteApiException
     {
         return callServicePostApi(
-                JOSE_VERIFY_API_PATH, request, JoseVerifyResponse.class);
+                JOSE_VERIFY_API_PATH, request, JoseVerifyResponse.class, options);
     }
 
 
     @Override
     public BackchannelAuthenticationResponse backchannelAuthentication(
-            BackchannelAuthenticationRequest request) throws AuthleteApiException
+            BackchannelAuthenticationRequest request, Options options) throws AuthleteApiException
     {
         return callServicePostApi(
                 BC_AUTHENTICATION_API_PATH, request,
-                BackchannelAuthenticationResponse.class);
+                BackchannelAuthenticationResponse.class, options);
     }
 
 
     @Override
     public BackchannelAuthenticationIssueResponse backchannelAuthenticationIssue(
-            BackchannelAuthenticationIssueRequest request) throws AuthleteApiException
+            BackchannelAuthenticationIssueRequest request, Options options) throws AuthleteApiException
     {
         return callServicePostApi(
                 BC_AUTHENTICATION_ISSUE_API_PATH, request,
-                BackchannelAuthenticationIssueResponse.class);
+                BackchannelAuthenticationIssueResponse.class, options);
     }
 
 
     @Override
     public BackchannelAuthenticationFailResponse backchannelAuthenticationFail(
-            BackchannelAuthenticationFailRequest request) throws AuthleteApiException
+            BackchannelAuthenticationFailRequest request, Options options) throws AuthleteApiException
     {
         return callServicePostApi(
                 BC_AUTHENTICATION_FAIL_API_PATH, request,
-                BackchannelAuthenticationFailResponse.class);
+                BackchannelAuthenticationFailResponse.class, options);
     }
 
 
     @Override
     public BackchannelAuthenticationCompleteResponse backchannelAuthenticationComplete(
-            BackchannelAuthenticationCompleteRequest request) throws AuthleteApiException
+            BackchannelAuthenticationCompleteRequest request, Options options) throws AuthleteApiException
     {
         return callServicePostApi(
                 BC_AUTHENTICATION_COMPLETE_API_PATH, request,
-                BackchannelAuthenticationCompleteResponse.class);
+                BackchannelAuthenticationCompleteResponse.class, options);
     }
 
 
     @Override
     public DeviceAuthorizationResponse deviceAuthorization(
-            DeviceAuthorizationRequest request) throws AuthleteApiException
+            DeviceAuthorizationRequest request, Options options) throws AuthleteApiException
     {
         return callServicePostApi(
                 DEVICE_AUTHORIZATION_API_PATH, request,
-                DeviceAuthorizationResponse.class);
+                DeviceAuthorizationResponse.class, options);
     }
 
 
     @Override
     public DeviceCompleteResponse deviceComplete(
-            DeviceCompleteRequest request) throws AuthleteApiException
+            DeviceCompleteRequest request, Options options) throws AuthleteApiException
     {
         return callServicePostApi(
                 DEVICE_COMPLETE_API_PATH, request,
-                DeviceCompleteResponse.class);
+                DeviceCompleteResponse.class, options);
     }
 
 
     @Override
     public DeviceVerificationResponse deviceVerification(
-            DeviceVerificationRequest request) throws AuthleteApiException
+            DeviceVerificationRequest request, Options options) throws AuthleteApiException
     {
         return callServicePostApi(
                 DEVICE_VERIFICATION_API_PATH, request,
-                DeviceVerificationResponse.class);
+                DeviceVerificationResponse.class, options);
     }
 
 
     @Override
     public PushedAuthReqResponse pushAuthorizationRequest(
-            PushedAuthReqRequest request) throws AuthleteApiException
+            PushedAuthReqRequest request, Options options) throws AuthleteApiException
     {
         return callServicePostApi(
                 PUSHED_AUTH_REQ_API_PATH, request,
-                PushedAuthReqResponse.class);
+                PushedAuthReqResponse.class, options);
     }
 
 
     @Override
-    public HskResponse hskCreate(HskCreateRequest request) throws AuthleteApiException
+    public HskResponse hskCreate(HskCreateRequest request, Options options) throws AuthleteApiException
     {
         return callServicePostApi(
                 HSK_CREATE_API_PATH, request,
-                HskResponse.class);
+                HskResponse.class, options);
     }
 
 
     @Override
-    public HskResponse hskDelete(String handle) throws AuthleteApiException
+    public HskResponse hskDelete(String handle, Options options) throws AuthleteApiException
     {
         return callServiceGetApi(
                 String.format(HSK_DELETE_API_PATH, handle),
-                HskResponse.class);
+                HskResponse.class, options);
     }
 
 
     @Override
-    public HskResponse hskGet(String handle) throws AuthleteApiException
+    public HskResponse hskGet(String handle, Options options) throws AuthleteApiException
     {
         return callServiceGetApi(
                 String.format(HSK_GET_API_PATH, handle),
-                HskResponse.class);
+                HskResponse.class, options);
     }
 
 
     @Override
-    public HskListResponse hskGetList() throws AuthleteApiException
+    public HskListResponse hskGetList(Options options) throws AuthleteApiException
     {
         return callServiceGetApi(
                 HSK_GET_LIST_API_PATH,
-                HskListResponse.class);
+                HskListResponse.class, options);
     }
 
 
     @SuppressWarnings("unchecked")
     @Override
-    public Map<String, String> echo(Map<String, String> parameters) throws AuthleteApiException
+    public Map<String, String> echo(Map<String, String> parameters, Options options) throws AuthleteApiException
     {
         return callGetApi(
-                null, ECHO_API_PATH, parameters, Map.class);
+                null, ECHO_API_PATH, parameters, Map.class, options);
     }
 
 
     @Override
-    public GMResponse gm(GMRequest request) throws AuthleteApiException
+    public GMResponse gm(GMRequest request, Options options) throws AuthleteApiException
     {
         return callServicePostApi(
                 GM_API_PATH, request,
-                GMResponse.class);
+                GMResponse.class, options);
     }
 
 
     @Override
-    public void updateClientLockFlag(String clientIdentifier, boolean clientLocked) throws AuthleteApiException
+    public void updateClientLockFlag(
+            String clientIdentifier, boolean clientLocked, Options options) throws AuthleteApiException
     {
         // Prepare a request body.
         ClientLockFlagUpdateRequest request =
@@ -1604,199 +1653,199 @@ class AuthleteApiImpl implements AuthleteApi
 
         callServicePostApi(
                 CLIENT_LOCK_FLAG_UPDATE_API_PATH, request,
-                ApiResponse.class);
+                ApiResponse.class, options);
     }
 
 
     @Override
     public FederationConfigurationResponse federationConfiguration(
-            FederationConfigurationRequest request) throws AuthleteApiException
+            FederationConfigurationRequest request, Options options) throws AuthleteApiException
     {
         return callServicePostApi(
                 FEDERATION_CONFIGURATION_API_PATH, request,
-                FederationConfigurationResponse.class);
+                FederationConfigurationResponse.class, options);
     }
 
 
     @Override
     public FederationRegistrationResponse federationRegistration(
-            FederationRegistrationRequest request) throws AuthleteApiException
+            FederationRegistrationRequest request, Options options) throws AuthleteApiException
     {
         return callServicePostApi(
                 FEDERATION_REGISTRATION_API_PATH, request,
-                FederationRegistrationResponse.class);
+                FederationRegistrationResponse.class, options);
     }
 
 
     @Override
     public CredentialIssuerMetadataResponse credentialIssuerMetadata(
-            CredentialIssuerMetadataRequest request) throws AuthleteApiException
+            CredentialIssuerMetadataRequest request, Options options) throws AuthleteApiException
     {
         // This API call fails because the /vci/metadata API is unavailable
         // in Authlete 2.x and older versions.
         return callServicePostApi(
                 VCI_METADATA_API_PATH, request,
-                CredentialIssuerMetadataResponse.class);
+                CredentialIssuerMetadataResponse.class, options);
     }
 
 
     @Override
     public CredentialJwtIssuerMetadataResponse credentialJwtIssuerMetadata(
-            CredentialJwtIssuerMetadataRequest request) throws AuthleteApiException
+            CredentialJwtIssuerMetadataRequest request, Options options) throws AuthleteApiException
     {
         // This API call fails because the /vci/jwtissuer API is unavailable
         // in Authlete 2.x and older versions.
         return callServicePostApi(
                 VCI_JWT_ISSUER_API_PATH, request,
-                CredentialJwtIssuerMetadataResponse.class);
+                CredentialJwtIssuerMetadataResponse.class, options);
     }
 
 
     @Override
     public CredentialIssuerJwksResponse credentialIssuerJwks(
-            CredentialIssuerJwksRequest request) throws AuthleteApiException
+            CredentialIssuerJwksRequest request, Options options) throws AuthleteApiException
     {
         // This API call fails because the /vci/jwks API is unavailable
         // in Authlete 2.x and older versions.
         return callServicePostApi(
                 VCI_JWKS_API_PATH, request,
-                CredentialIssuerJwksResponse.class);
+                CredentialIssuerJwksResponse.class, options);
     }
 
 
     @Override
     public CredentialOfferCreateResponse credentialOfferCreate(
-            CredentialOfferCreateRequest request) throws AuthleteApiException
+            CredentialOfferCreateRequest request, Options options) throws AuthleteApiException
     {
         // This API call fails because the /vci/offer/create API is unavailable
         // in Authlete 2.x and older versions.
         return callServicePostApi(
                 VCI_OFFER_CREATE_API_PATH, request,
-                CredentialOfferCreateResponse.class);
+                CredentialOfferCreateResponse.class, options);
     }
 
 
     @Override
     public CredentialOfferInfoResponse credentialOfferInfo(
-            CredentialOfferInfoRequest request) throws AuthleteApiException
+            CredentialOfferInfoRequest request, Options options) throws AuthleteApiException
     {
         // This API call fails because the /vci/offer/info API is unavailable
         // in Authlete 2.x and older versions.
         return callServicePostApi(
                 VCI_OFFER_INFO_API_PATH, request,
-                CredentialOfferInfoResponse.class);
+                CredentialOfferInfoResponse.class, options);
     }
 
 
     @Override
     public CredentialSingleParseResponse credentialSingleParse(
-            CredentialSingleParseRequest request) throws AuthleteApiException
+            CredentialSingleParseRequest request, Options options) throws AuthleteApiException
     {
         // This API call fails because the /vci/single/parse API is unavailable
         // in Authlete 2.x and older versions.
         return callServicePostApi(
                 VCI_SINGLE_PARSE_API_PATH, request,
-                CredentialSingleParseResponse.class);
+                CredentialSingleParseResponse.class, options);
     }
 
 
     @Override
     public CredentialSingleIssueResponse credentialSingleIssue(
-            CredentialSingleIssueRequest request) throws AuthleteApiException
+            CredentialSingleIssueRequest request, Options options) throws AuthleteApiException
     {
         // This API call fails because the /vci/single/issue API is unavailable
         // in Authlete 2.x and older versions.
         return callServicePostApi(
                 VCI_SINGLE_ISSUE_API_PATH, request,
-                CredentialSingleIssueResponse.class);
+                CredentialSingleIssueResponse.class, options);
     }
 
 
     @Override
     public CredentialBatchParseResponse credentialBatchParse(
-            CredentialBatchParseRequest request) throws AuthleteApiException
+            CredentialBatchParseRequest request, Options options) throws AuthleteApiException
     {
         // This API call fails because the /vci/batch/parse API is unavailable
         // in Authlete 2.x and older versions.
         return callServicePostApi(
                 VCI_BATCH_PARSE_API_PATH, request,
-                CredentialBatchParseResponse.class);
+                CredentialBatchParseResponse.class, options);
     }
 
 
     @Override
     public CredentialBatchIssueResponse credentialBatchIssue(
-            CredentialBatchIssueRequest request) throws AuthleteApiException
+            CredentialBatchIssueRequest request, Options options) throws AuthleteApiException
     {
         // This API call fails because the /vci/batch/issue API is unavailable
         // in Authlete 2.x and older versions.
         return callServicePostApi(
                 VCI_BATCH_ISSUE_API_PATH, request,
-                CredentialBatchIssueResponse.class);
+                CredentialBatchIssueResponse.class, options);
     }
 
 
     @Override
     public CredentialDeferredParseResponse credentialDeferredParse(
-            CredentialDeferredParseRequest request) throws AuthleteApiException
+            CredentialDeferredParseRequest request, Options options) throws AuthleteApiException
     {
         // This API call fails because the /vci/deferred/parse API is unavailable
         // in Authlete 2.x and older versions.
         return callServicePostApi(
                 VCI_DEFERRED_PARSE_API_PATH, request,
-                CredentialDeferredParseResponse.class);
+                CredentialDeferredParseResponse.class, options);
     }
 
 
     @Override
     public CredentialDeferredIssueResponse credentialDeferredIssue(
-            CredentialDeferredIssueRequest request) throws AuthleteApiException
+            CredentialDeferredIssueRequest request, Options options) throws AuthleteApiException
     {
         // This API call fails because the /vci/deferred/issue API is unavailable
         // in Authlete 2.x and older versions.
         return callServicePostApi(
                 VCI_DEFERRED_ISSUE_API_PATH, request,
-                CredentialDeferredIssueResponse.class);
+                CredentialDeferredIssueResponse.class, options);
     }
 
 
     @Override
     public IDTokenReissueResponse idTokenReissue(
-            IDTokenReissueRequest request) throws AuthleteApiException
+            IDTokenReissueRequest request, Options options) throws AuthleteApiException
     {
         return callServicePostApi(
                 ID_TOKEN_REISSUE_API_PATH, request,
-                IDTokenReissueResponse.class);
+                IDTokenReissueResponse.class, options);
     }
 
 
     @Override
     public AuthorizationTicketInfoResponse authorizationTicketInfo(
-            AuthorizationTicketInfoRequest request) throws AuthleteApiException
+            AuthorizationTicketInfoRequest request, Options options) throws AuthleteApiException
     {
         // This API call fails because the /auth/authorization/ticket/info API
         // is unavailable in Authlete 2.x and older versions.
         return callServicePostApi(
                 AUTH_AUTHORIZATION_TICKET_INFO_API_PATH, request,
-                AuthorizationTicketInfoResponse.class);
+                AuthorizationTicketInfoResponse.class, options);
     }
 
 
     @Override
     public AuthorizationTicketUpdateResponse authorizationTicketUpdate(
-            AuthorizationTicketUpdateRequest request) throws AuthleteApiException
+            AuthorizationTicketUpdateRequest request, Options options) throws AuthleteApiException
     {
         // This API call fails because the /auth/authorization/ticket/update API
         // is unavailable in Authlete 2.x and older versions.
         return callServicePostApi(
                 AUTH_AUTHORIZATION_TICKET_UPDATE_API_PATH, request,
-                AuthorizationTicketUpdateResponse.class);
+                AuthorizationTicketUpdateResponse.class, options);
     }
 
 
     @Override
     public TokenCreateBatchResponse tokenCreateBatch(
-            TokenCreateRequest[] request, boolean isDryRun) throws AuthleteApiException
+            TokenCreateRequest[] request, boolean isDryRun, Options options) throws AuthleteApiException
     {
         // This is unavailable in Authlete 2.x and older versions.
         throw new AuthleteApiException(
@@ -1806,7 +1855,7 @@ class AuthleteApiImpl implements AuthleteApi
 
     @Override
     public TokenCreateBatchStatusResponse getTokenCreateBatchStatus(
-            String requestId) throws AuthleteApiException
+            String requestId, Options options) throws AuthleteApiException
     {
         // This is unavailable in Authlete 2.x and older versions.
         throw new AuthleteApiException(

--- a/src/main/java/com/authlete/common/api/AuthleteApiImpl.java
+++ b/src/main/java/com/authlete/common/api/AuthleteApiImpl.java
@@ -585,9 +585,9 @@ class AuthleteApiImpl implements AuthleteApi
 
     private static boolean isReservedRequestHeader(String key)
     {
-        return key.equals(HttpHeader.ACCEPT) ||
-               key.equals(HttpHeader.AUTHORIZATION) ||
-               key.equals(HttpHeader.CONTENT_TYPE);
+        return key.equalsIgnoreCase(HttpHeader.ACCEPT) ||
+               key.equalsIgnoreCase(HttpHeader.AUTHORIZATION) ||
+               key.equalsIgnoreCase(HttpHeader.CONTENT_TYPE);
     }
 
 

--- a/src/main/java/com/authlete/common/api/Options.java
+++ b/src/main/java/com/authlete/common/api/Options.java
@@ -24,6 +24,8 @@ import java.util.Map;
  * Request options.
  *
  * @author hidebike712
+ *
+ * @since 4.15
  */
 public class Options
 {
@@ -35,7 +37,7 @@ public class Options
      * is immutable.
      *
      * @return
-     *         The custom request headers. Note that the returned map is imuutable.
+     *         The custom request headers. Note that the returned map is immutable.
      */
     public Map<String, String> getHeaders()
     {

--- a/src/main/java/com/authlete/common/api/Options.java
+++ b/src/main/java/com/authlete/common/api/Options.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2024 Authlete, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.authlete.common.api;
+
+
+import java.util.Collections;
+import java.util.Map;
+
+
+/**
+ * Request options.
+ *
+ * @author hidebike712
+ */
+public class Options
+{
+    Map<String, String> headers;
+
+
+    /**
+     * Get the custom request headers for a request. Note that the returned map
+     * is immutable.
+     *
+     * @return
+     *         The custom request headers. Note that the returned map is imuutable.
+     */
+    public Map<String, String> getHeaders()
+    {
+        return headers == null ? null : Collections.unmodifiableMap(headers);
+    }
+
+
+    /**
+     * Set the custom request headers for a request.
+     *
+     * @param headers
+     *         The custom request headers.
+     *
+     * @return
+     *         {@code this} object.
+     */
+    public Options setHeaders(Map<String, String> headers)
+    {
+        this.headers = headers;
+
+        return this;
+    }
+}


### PR DESCRIPTION
This PR adds an options parameter to each API method. For example, it can be used as follows:

```
AuthleteApi api = ...;

Map<String, String> customHeaders1 = Map.of("Request-Id", "my-req-id-1");
AuthorizationRequest authzReq = ...;
api.authorization(authzReq, new Options().setHeaders(customHeaders1));

Map<String, String> customHeaders2 = Map.of("Request-Id", "my-req-id-2");
AuthorizationIssueRequest authzIssueReq = ...;
api.authorizationIssue(authzIssueReq, new Options().setHeaders(customHeaders2));
```