### PR TITLE
chore: Update Sonatyp publish URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -189,7 +189,7 @@
 
                 <repository>
                     <id>authlete</id>
-                    <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+                    <url>https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/</url>
                 </repository>
             </distributionManagement>
             <repositories>


### PR DESCRIPTION
Update distribution endpoint because of OSSRH sunset