### PR TITLE
Add new "inScopeForTokenMigration" flag in the Client object

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,9 @@ CHANGES
     * Added the `setResponseHeaders(Map<String, List<String>>)` method.
     * Added support for extracting HTTP response headers from Authlete API calls.
 
+- `Client` class
+    * Added the `isInScopeForTokenMigration()` method.
+    * Added the `setInScopeForTokenMigration(boolean)` method.
 
 4.22 (2025-08-14)
 -----------------

--- a/src/main/java/com/authlete/common/dto/Client.java
+++ b/src/main/java/com/authlete/common/dto/Client.java
@@ -583,6 +583,13 @@ public class Client implements Serializable
      */
     private boolean mtlsEndpointAliasesUsed;
 
+    /**
+     * Indicates if the client is inscope for token migration.
+     *
+     * @since Authlete 4.23
+     */
+    private boolean inScopeForTokenMigration;
+
 
     /*
      * For OpenID Federation 1.0.
@@ -5204,6 +5211,39 @@ public class Client implements Serializable
     public Client setMtlsEndpointAliasesUsed(boolean mtlsEndpointAliasesUsed)
     {
         this.mtlsEndpointAliasesUsed = mtlsEndpointAliasesUsed;
+
+        return this;
+    }
+
+
+    /**
+     * Get the value that indicates whether this Client is in scope for token migration.
+     *
+     * @return
+     *         The value that indicates whether this Client is in scope for token migration.
+     *
+     * @since Authlete 4.23
+     */
+    public boolean isInScopeForTokenMigration()
+    {
+        return inScopeForTokenMigration;
+    }
+
+
+    /**
+     * Sets the flag that indicates that this Client is in scope for token migration.
+     *
+     * @param inScopeForTokenMigration
+     *         The new value for the flag to indicates whether this Client is in scope for token migration.
+     *
+     * @return
+     *         The {@link Client} after setting the provided property.
+     *
+     * @since Authlete 4.23
+     */
+    public Client setInScopeForTokenMigration(boolean inScopeForTokenMigration)
+    {
+        this.inScopeForTokenMigration = inScopeForTokenMigration;
 
         return this;
     }


### PR DESCRIPTION
This adds a new boolean flag property to the Client class.
It will be used to determine whether a client's tokens should be migrated and also will be configurable via the UI.