### PR TITLE
feat: add response headers support to ApiResponse

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,15 @@
 CHANGES
 =======
 
+4.23 (TBD)
+----------
+
+- `ApiResponse` class
+    * Added the `getResponseHeaders()` method.
+    * Added the `setResponseHeaders(Map<String, List<String>>)` method.
+    * Added support for extracting HTTP response headers from Authlete API calls.
+
+
 4.22 (2025-08-14)
 -----------------
 

--- a/src/main/java/com/authlete/common/dto/ApiResponse.java
+++ b/src/main/java/com/authlete/common/dto/ApiResponse.java
@@ -17,6 +17,8 @@ package com.authlete.common.dto;
 
 
 import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
 
 
 /**
@@ -32,6 +34,7 @@ public class ApiResponse implements Serializable
 
     private String resultCode;
     private String resultMessage;
+    private Map<String, List<String>> responseHeaders;
 
 
     /**
@@ -80,5 +83,34 @@ public class ApiResponse implements Serializable
     public void setResultMessage(String message)
     {
         this.resultMessage = message;
+    }
+
+
+    /**
+     * Get the HTTP response headers returned from an Authlete API call.
+     *
+     * @return
+     *         A map of HTTP response headers. May be {@code null} or empty.
+     *
+     * @since 4.23
+     */
+    public Map<String, List<String>> getResponseHeaders()
+    {
+        return responseHeaders;
+    }
+
+
+    /**
+     * Set the HTTP response headers returned from an Authlete API call.
+     *
+     * @param responseHeaders
+     *         A map of HTTP response headers where each key is a header name
+     *         and the corresponding value is a list of header values.
+     *
+     * @since 4.23
+     */
+    public void setResponseHeaders(Map<String, List<String>> responseHeaders)
+    {
+        this.responseHeaders = responseHeaders;
     }
 }


### PR DESCRIPTION
- Added responseHeaders field to store HTTP response headers
- Added getter/setter methods with proper JavaDoc
- Updated CHANGES.md for version 4.23

This enables downstream libraries to extract and provide access to HTTP response headers from Authlete API calls, particularly the Request-Id header requested by customers.