### PR TITLE
feat: add note to TokenRevokeRequest and TokenRevokeResponse about 20-token-per-call limit

### DIFF
--- a/src/main/java/com/authlete/common/dto/TokenRevokeRequest.java
+++ b/src/main/java/com/authlete/common/dto/TokenRevokeRequest.java
@@ -79,6 +79,14 @@ import java.io.Serializable;
  * the API returns {@code 400 Bad Request}.
  * </p>
  * </ol>
+ * 
+ * <p>
+ * Bulk revocation with `clientIdentifier` only, `clientIdentifier` + `subject`, 
+ * or `subject` only deletes at most **20 tokens per request** 
+ * (the default of `token.revoke.count.max` in `ServerConfiguration.java`). If the
+ * target has more than 20 tokens, the response `count` will be 20 and the remainder 
+ * is left untouched. To fully wipe them, call the endpoint repeatedly until `count` returns 0.
+ * </p>
  *
  * @since 3.26
  * @since Authlete 2.2.29

--- a/src/main/java/com/authlete/common/dto/TokenRevokeResponse.java
+++ b/src/main/java/com/authlete/common/dto/TokenRevokeResponse.java
@@ -26,7 +26,11 @@ public class TokenRevokeResponse extends ApiResponse
 {
     private static final long serialVersionUID = 1L;
 
-
+    /**
+     * If the
+     * target has more than 20 tokens, the response `count` will be 20 and the remainder 
+     * is left untouched. To fully wipe them, call the endpoint repeatedly until `count` returns 0.
+     */
     private int count;
 
 


### PR DESCRIPTION
Clickup ticket: https://app.clickup.com/t/9002222883/ENG-5662

Problem

There is an undocumented limitation on the /api/auth/token/revoke API call that silently restricts bulk revocation to 20 tokens per request (controlled by the token.revoke.count.max parameter). Customers wrongly believe that all tokens will be revoked with just one call; however, this is not the case, and they need to make multiple calls until the count drops to zero. This was discovered by a customer (Unisys-Resonatex) through an unpleasant experience during a security event that required the revocation of 350,000 tokens.
We also never told customers the safe way to do bulk revocation. Just looping the API without preparation can go wrong in multiple ways.

Java SDK (authlete-java-common)

-  Add a note to TokenRevokeRequest class explaining the 20-per-call cap and that you need to loop
-  Add a note to TokenRevokeResponse#count field saying loop until this hits zero

Content source: https://git.authlete.com/support-tools/agent-knowledge/-/merge_requests/39/diffs#a4afaf7dfe99f2e5f00d1d1aa5ff099f07325867